### PR TITLE
f: replace individual implementations with macros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
 
     - name: "Stable - Test"
       rust: stable
-      script: RUST_BACKTRACE=1 cargo test
+      script: RUST_BACKTRACE=full cargo test
 
     - name: "Nightly - LintFormat"
       rust: nightly
@@ -33,7 +33,7 @@ matrix:
       before_script:
         - cargo install cargo-expand
         - cargo expand
-      script: RUST_BACKTRACE=1 cargo test
+      script: RUST_BACKTRACE=full cargo test
 
   allow_failures:
     - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ matrix:
 
     - name: "Stable - Test"
       rust: stable
+      before_script:
+        - cargo install cargo-expand
+        - cargo expand
       script: RUST_BACKTRACE=1 cargo test
 
     - name: "Nightly - LintFormat"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ matrix:
 
     - name: "Stable - Test"
       rust: stable
-      before_script:
-        - cargo install cargo-expand
-        - cargo expand
       script: RUST_BACKTRACE=1 cargo test
 
     - name: "Nightly - LintFormat"
@@ -33,7 +30,10 @@ matrix:
 
     - name: "Nightly - Test"
       rust: nightly
-      script: scripts/check test
+      before_script:
+        - cargo install cargo-expand
+        - cargo expand
+      script: RUST_BACKTRACE=1 cargo test
 
   allow_failures:
     - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
 
     - name: "Stable - Test"
       rust: stable
-      script: RUST_BACKTRACE=full cargo test
+      script: scripts/check test
 
     - name: "Nightly - LintFormat"
       rust: nightly
@@ -30,7 +30,7 @@ matrix:
 
     - name: "Nightly - Test"
       rust: nightly
-      script: RUST_BACKTRACE=full cargo test
+      script: scripts/check test
 
   allow_failures:
     - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,6 @@ matrix:
 
     - name: "Nightly - Test"
       rust: nightly
-      before_script:
-        - cargo install cargo-expand
-        - cargo expand
       script: RUST_BACKTRACE=full cargo test
 
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
 
     - name: "Stable - Test"
       rust: stable
-      script: scripts/check test
+      script: RUST_BACKTRACE=1 cargo test
 
     - name: "Nightly - LintFormat"
       rust: nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@
 extern crate alloc;
 
 mod murmur3;
+mod prelude;
 mod splitmix64;
 
 mod xor16;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -189,7 +189,8 @@ macro_rules! from_impl(
                 let mut q_sizes: [usize; 3] = [0, 0, 0];
                 for b in 0..3 {
                     for idx in 0..(block_length) {
-                        try_enqueue!(block ( &H[b] ), set idx; queue block ( &mut Q[b] ), with size ( q_sizes[b] ));
+                        try_enqueue!(block &H[b], set idx;
+                                     queue block &mut Q[b], with size q_sizes[b]);
                     }
                 }
 
@@ -217,7 +218,8 @@ macro_rules! from_impl(
                                     let idx = h!(index block *j, of length block_length, using ki.hash);
                                     H[*j][idx].mask ^= ki.hash;
                                     H[*j][idx].count -= 1;
-                                    try_enqueue!(block ( &H[*j] ), set idx; queue block ( &mut Q[*j] ), with size ( q_sizes[*j] ));
+                                    try_enqueue!(block &H[*j], set idx;
+                                                 queue block &mut Q[*j], with size q_sizes[*j]);
                                 }
                             }
                         };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -101,6 +101,20 @@ macro_rules! make_block(
     };
 );
 
+/// Creates a block of sets, each set being of type T.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! try_enqueue(
+    (block $H_block:ident at set $idx:ident, queue block $Q_block:ident with size $qblock_size:ident) => {
+        if $H_block[$idx].count == 1 {
+            $Q_block[*$qblock_size].index = $idx;
+            // If there is only one key, the mask contains it wholly.
+            $Q_block[*$qblock_size].hash = $H_block[$idx].mask;
+            *$qblock_size += 1;
+        }
+    };
+);
+
 /// Enqueues a set from the temporary construction array H if the set contains only one key.
 #[allow(non_snake_case)]
 #[inline]
@@ -110,12 +124,7 @@ pub fn try_enqueue(
     Q_block: &mut [KeyIndex],
     qblock_size: &mut usize,
 ) {
-    if H_block[idx].count == 1 {
-        Q_block[*qblock_size].index = idx;
-        // If there is only one key, the mask contains it wholly.
-        Q_block[*qblock_size].hash = H_block[idx].mask;
-        *qblock_size += 1;
-    }
+    try_enqueue!(block H_block at set idx, queue block Q_block with size qblock_size)
 }
 
 /// Creates a `contains(u64)` implementation for an xor filter of fingerprint type `$fpty`.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,7 @@
 //! Common methods for xor filters.
 
 use crate::murmur3;
+use alloc::{boxed::Box, vec::Vec};
 
 /// A set of hashes indexing three blocks.
 pub struct HashSet {
@@ -11,26 +12,18 @@ pub struct HashSet {
 }
 
 impl HashSet {
-    #[inline]
     pub const fn from(key: u64, block_length: usize, seed: u64) -> Self {
         let hash = mix(key, seed);
 
         Self {
             hash,
             hset: [
-                crate::h!(index block 0, of length block_length, using hash),
-                crate::h!(index block 1, of length block_length, using hash),
-                crate::h!(index block 2, of length block_length, using hash),
+                h(0, hash, block_length),
+                h(1, hash, block_length),
+                h(2, hash, block_length),
             ],
         }
     }
-}
-
-/// Applies a finalization mix to a randomly-seeded key, resulting in an avalanched hash. This
-/// helps avoid high false-positive ratios (see Section 4 in the paper).
-#[inline]
-const fn mix(key: u64, seed: u64) -> u64 {
-    murmur3::mix64(key.overflowing_add(seed).0)
 }
 
 /// The hash of a key and the index of that key in the construction array H.
@@ -47,94 +40,83 @@ pub struct HSet {
     pub mask: u64,
 }
 
-/// Computes a fingerprint.
-#[doc(hidden)]
-#[macro_export]
-macro_rules! fingerprint(
-    ($hash:expr) => {
-        $hash ^ ($hash >> 32)
-    };
-);
+/// Applies a finalization mix to a randomly-seeded key, resulting in an avalanched hash. This
+/// helps avoid high false-positive ratios (see Section 4 in the paper).
+#[inline]
+pub const fn mix(key: u64, seed: u64) -> u64 {
+    murmur3::mix64(key.overflowing_add(seed).0)
+}
 
-/// Rotate left
-#[doc(hidden)]
-#[macro_export]
-macro_rules! rotl64(
-    ($n:expr, by $c:expr) => {
-        ($n << ($c & 63)) | ($n >> ((-$c) & 63))
-    };
-);
+#[inline]
+pub const fn rotl64(n: u64, c: isize) -> u64 {
+    (n << (c & 63)) | (n >> ((-c) & 63))
+}
 
 /// [A fast alternative to the modulo reduction](http://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/)
-#[doc(hidden)]
-#[macro_export]
-macro_rules! reduce(
-    ($hash:ident on interval $n:expr) => {
-        (($hash as u64 * $n as u64) >> 32) as usize
-    };
-);
+#[inline]
+pub const fn reduce(hash: u32, n: usize) -> usize {
+    ((hash as u64 * n as u64) >> 32) as usize
+}
 
 /// Computes a hash indexing the i'th filter block.
-#[doc(hidden)]
-#[macro_export]
-macro_rules! h(
-    (index block $i:expr, of length $block_length:expr, using $hash:expr) => {
-        {
-            let rot = $crate::rotl64!($hash, by (($i as isize) * 21)) as u32; // shift hash to correct block interval
-            $crate::reduce!(rot on interval $block_length)
-        }
-    };
-);
+#[inline]
+pub const fn h(i: usize, hash: u64, block_length: usize) -> usize {
+    let rot = rotl64(hash, (i as isize) * 21) as u32; // shift hash to correct block interval
+    reduce(rot, block_length)
+}
+
+#[inline]
+pub const fn fingerprint(hash: u64) -> u64 {
+    hash ^ (hash >> 32)
+}
 
 /// Creates a block of sets, each set being of type T.
-#[doc(hidden)]
-#[macro_export]
-macro_rules! make_block(
-    ($num:ident sets of $T:ty) => {
-        {
-            let mut sets_block: Vec<$T> = Vec::with_capacity($num);
-            unsafe {
-                sets_block.set_len($num);
-            }
-            sets_block.into_boxed_slice()
-        }
-    };
-);
+#[inline]
+pub fn sets_block<T>(size: usize) -> Box<[T]> {
+    let mut sets_block = Vec::with_capacity(size);
+    unsafe {
+        sets_block.set_len(size);
+    }
+    sets_block.into_boxed_slice()
+}
 
 /// Enqueues a set from the temporary construction array H if the set contains only one key.
-#[doc(hidden)]
-#[macro_export]
-macro_rules! try_enqueue(
-    (block $H_block:expr, set #$idx:expr; on queue block $Q_block:expr, of size $Qblock_size:expr) => {
-        if $H_block[$idx].count == 1 {
-            $Q_block[$Qblock_size].index = $idx;
-            // If there is only one key, the mask contains it wholly.
-            $Q_block[$Qblock_size].hash = $H_block[$idx].mask;
-            $Qblock_size += 1;
-        }
-    };
-);
+#[allow(non_snake_case)]
+#[inline]
+pub fn try_enqueue(
+    H_block: &[HSet],
+    idx: usize,
+    Q_block: &mut [KeyIndex],
+    qblock_size: &mut usize,
+) {
+    if H_block[idx].count == 1 {
+        Q_block[*qblock_size].index = idx;
+        // If there is only one key, the mask contains it wholly.
+        Q_block[*qblock_size].hash = H_block[idx].mask;
+        *qblock_size += 1;
+    }
+}
 
 /// Creates a `contains(u64)` implementation for an xor filter of fingerprint type `$fpty`.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! contains_impl(
-    ($key:ident, $self:expr, fingerprint $fpty:ty) => {
-        {
-            use $crate::prelude::HashSet;
+     ($key:ident, $self:expr, fingerprint $fpty:ty) => {
+         {
+             use $crate::prelude::HashSet;
 
-            let HashSet {
-                hash,
-                hset: [h0, h1, h2],
-            } = HashSet::from($key, $self.block_length, $self.seed);
-            let fp = $crate::fingerprint!(hash) as $fpty;
+             let HashSet {
+                 hash,
+                 hset: [h0, h1, h2],
+             } = HashSet::from($key, $self.block_length, $self.seed);
+             let fp = $crate::prelude::fingerprint(hash) as $fpty;
 
-            fp == $self.fingerprints[h0]
-                ^ $self.fingerprints[(h1 + $self.block_length)]
-                ^ $self.fingerprints[(h2 + 2 * $self.block_length)]
-        }
-    };
-);
+             fp == $self.fingerprints[h0]
+                 ^ $self.fingerprints[(h1 + $self.block_length)]
+                 ^ $self.fingerprints[(h2 + 2 * $self.block_length)]
+         }
+     };
+ );
 
 /// Creates an `from(&[u64])` implementation for an xor filter of fingerprint type `$fpty`.
 #[doc(hidden)]
@@ -143,12 +125,8 @@ macro_rules! from_impl(
     ($keys:ident fingerprint $fpty:ty) => {
         {
             use $crate::{
-                fingerprint,
-                h,
-                make_block,
-                prelude::{HashSet, HSet, KeyIndex},
+                prelude::{HashSet, HSet, KeyIndex, sets_block, try_enqueue, fingerprint, h},
                 splitmix64::splitmix64,
-                try_enqueue,
             };
 
             // See Algorithm 3 in the paper.
@@ -159,17 +137,17 @@ macro_rules! from_impl(
 
             #[allow(non_snake_case)]
             let mut H: [Box<[HSet]>; 3] = [
-                make_block!(capacity sets of HSet),
-                make_block!(capacity sets of HSet),
-                make_block!(capacity sets of HSet),
+                sets_block(capacity),
+                sets_block(capacity),
+                sets_block(capacity),
             ];
             #[allow(non_snake_case)]
             let mut Q: [Box<[KeyIndex]>; 3] = [
-                make_block!(capacity sets of KeyIndex),
-                make_block!(capacity sets of KeyIndex),
-                make_block!(capacity sets of KeyIndex),
+                sets_block(capacity),
+                sets_block(capacity),
+                sets_block(capacity),
             ];
-            let mut stack: Box<[KeyIndex]> = make_block!(capacity sets of KeyIndex);
+            let mut stack: Box<[KeyIndex]> = sets_block(capacity);
 
             let mut rng = 1;
             let mut seed = splitmix64(&mut rng);
@@ -189,8 +167,7 @@ macro_rules! from_impl(
                 let mut q_sizes: [usize; 3] = [0, 0, 0];
                 for b in 0..3 {
                     for idx in 0..(block_length) {
-                        try_enqueue!(block H[b], set #idx;
-                                     on queue block Q[b], of size q_sizes[b]);
+                        try_enqueue(&H[b], idx, &mut Q[b], &mut q_sizes[b]);
                     }
                 }
 
@@ -215,12 +192,11 @@ macro_rules! from_impl(
                                 // Remove the element from every other set and enqueue any sets that now only
                                 // have one element.
                                 for j in &[$a, $b] {
-                                    let idx = h!(index block *j, of length block_length, using ki.hash);
+                                    let idx = h(*j, ki.hash, block_length);
                                     H[*j][idx].mask ^= ki.hash;
                                     assert!(H[*j][idx].count != 0, "block {}, queue block size {}", $block, q_sizes[$block]);
                                     H[*j][idx].count -= 1;
-                                    try_enqueue!(block H[*j], set #idx;
-                                                 on queue block Q[*j], of size q_sizes[*j]);
+                                    try_enqueue(&H[*j], idx, &mut Q[*j], &mut q_sizes[*j]);
                                 }
                             }
                         };
@@ -246,12 +222,12 @@ macro_rules! from_impl(
 
             // Construct all fingerprints (see Algorithm 4 in the paper).
             #[allow(non_snake_case)]
-            let mut B = make_block!(capacity sets of $fpty);
+            let mut B = sets_block(capacity);
             for ki in stack.iter().rev() {
-                B[ki.index] = fingerprint!(ki.hash) as $fpty
-                    ^ B[h!(index block 0, of length block_length, using ki.hash)]
-                    ^ B[(h!(index block 1, of length block_length, using ki.hash) + block_length)]
-                    ^ B[(h!(index block 2, of length block_length, using ki.hash) + 2 * block_length)];
+                B[ki.index] = fingerprint(ki.hash) as $fpty
+                    ^ B[h(0, ki.hash, block_length)]
+                    ^ B[(h(1, ki.hash, block_length) + block_length)]
+                    ^ B[(h(2, ki.hash, block_length) + 2 * block_length)];
             }
 
             Self {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -190,7 +190,7 @@ macro_rules! from_impl(
                 for b in 0..3 {
                     for idx in 0..(block_length) {
                         try_enqueue!(block &H[b], set idx;
-                                     queue block &mut Q[b], with size q_sizes[b]);
+                                     queue block Q[b], with size q_sizes[b]);
                     }
                 }
 
@@ -219,7 +219,7 @@ macro_rules! from_impl(
                                     H[*j][idx].mask ^= ki.hash;
                                     H[*j][idx].count -= 1;
                                     try_enqueue!(block &H[*j], set idx;
-                                                 queue block &mut Q[*j], with size q_sizes[*j]);
+                                                 queue block Q[*j], with size q_sizes[*j]);
                                 }
                             }
                         };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -130,136 +130,111 @@ macro_rules! from_impl(
             };
 
             // See Algorithm 3 in the paper.
-         let num_keys = $keys.len();
-         let capacity = (1.23 * num_keys as f64) as usize + 32;
-         let capacity = capacity / 3 * 3; // round to nearest multiple of 3
-         let block_length = capacity / 3;
+            let num_keys = $keys.len();
+            let capacity = (1.23 * num_keys as f64) as usize + 32;
+            let capacity = capacity / 3 * 3; // round to nearest multiple of 3
+            let block_length = capacity / 3;
 
-         #[allow(non_snake_case)]
-         let mut Q: [Box<[KeyIndex]>; 3] = [
-             sets_block(capacity),
-             sets_block(capacity),
-             sets_block(capacity),
-         ];
-         #[allow(non_snake_case)]
-         let mut H: [Box<[HSet]>; 3] = [
-             sets_block(capacity),
-             sets_block(capacity),
-             sets_block(capacity),
-         ];
-         let mut stack: Box<[KeyIndex]> = sets_block(num_keys);
+            #[allow(non_snake_case)]
+            let mut Q: [Box<[KeyIndex]>; 3] = [
+                sets_block(capacity),
+                sets_block(capacity),
+                sets_block(capacity),
+            ];
+            #[allow(non_snake_case)]
+            let mut H: [Box<[HSet]>; 3] = [
+                sets_block(capacity),
+                sets_block(capacity),
+                sets_block(capacity),
+            ];
+            let mut stack: Box<[KeyIndex]> = sets_block(num_keys);
 
-         let mut rng = 1;
-         let mut seed = splitmix64(&mut rng);
-         loop {
-             // Populate H by adding each key to its respective set.
-             for key in $keys.iter() {
-                 let HashSet { hash, hset } = HashSet::from(*key, block_length, seed);
+            let mut rng = 1;
+            let mut seed = splitmix64(&mut rng);
+            loop {
+                // Populate H by adding each key to its respective set.
+                for key in $keys.iter() {
+                    let HashSet { hash, hset } = HashSet::from(*key, block_length, seed);
 
-                 for b in 0..3 {
-                     let setindex = hset[b];
-                     H[b][setindex].mask ^= hash;
-                     H[b][setindex].count += 1;
-                 }
-             }
+                    for b in 0..3 {
+                        let setindex = hset[b];
+                        H[b][setindex].mask ^= hash;
+                        H[b][setindex].count += 1;
+                    }
+                }
 
-             // Scan for sets with a single key. Add these keys to the queue.
-             let mut q_sizes: [usize; 3] = [0, 0, 0];
-             for b in 0..3 {
-                 for idx in 0..(block_length) {
-                     try_enqueue(&H[b], idx, &mut Q[b], &mut q_sizes[b]);
-                 }
-             }
+                // Scan for sets with a single key. Add these keys to the queue.
+                let mut q_sizes: [usize; 3] = [0, 0, 0];
+                for b in 0..3 {
+                    for idx in 0..(block_length) {
+                        try_enqueue(&H[b], idx, &mut Q[b], &mut q_sizes[b]);
+                    }
+                }
 
-             let mut stack_size = 0;
-             while q_sizes.iter().sum::<usize>() > 0 {
-                 while q_sizes[0] > 0 {
-                     // Remove an element from the queue.
-                     q_sizes[0] -= 1;
-                     let ki = Q[0][q_sizes[0]];
-                     if H[0][ki.index].count == 0 {
-                         continue;
-                     }
-                     // If it's the only element in its respective set in H, add it to the output
-                     // stack.
-                     stack[stack_size] = ki;
-                     stack_size += 1;
+                let mut stack_size = 0;
+                while q_sizes.iter().sum::<usize>() > 0 {
+                    macro_rules! dequeue(
+                         (block $block:expr, other blocks being $a:expr, $b:expr) => {
+                             while q_sizes[$block] > 0 {
+                                 // Remove an element from the queue.
+                                 q_sizes[$block] -= 1;
+                                 let mut ki = Q[$block][q_sizes[$block]];
+                                 if H[$block][ki.index].count == 0 {
+                                     continue;
+                                 }
 
-                     // Remove the element from every other set and enqueue any sets that now only
-                     // have one element.
-                     for j in &[1, 2] {
-                         let idx = h(*j, ki.hash, block_length);
-                         H[*j][idx].mask ^= ki.hash;
-                         H[*j][idx].count -= 1;
-                         try_enqueue(&H[*j], idx, &mut Q[*j], &mut q_sizes[*j]);
-                     }
-                 }
+                                 // If it's the only element in its respective set in H, add it to
+                                 // the output stack.
+                                 ki.index += $block * block_length;
+                                 stack[stack_size] = ki;
+                                 stack_size += 1;
 
-                 while q_sizes[1] > 0 {
-                     q_sizes[1] -= 1;
-                     let mut ki = Q[1][q_sizes[1]];
-                     if H[1][ki.index].count == 0 {
-                         continue;
-                     }
-                     ki.index += block_length;
-                     stack[stack_size] = ki;
-                     stack_size += 1;
+                                 // Remove the element from every other set and enqueue any sets
+                                 // that now only have one element.
+                                 for j in &[$a, $b] {
+                                     let idx = h(*j, ki.hash, block_length);
+                                     H[*j][idx].mask ^= ki.hash;
+                                     assert!(H[*j][idx].count != 0, "block {}, queue block size {}", $block, q_sizes[$block]);
+                                     H[*j][idx].count -= 1;
+                                     try_enqueue(&H[*j], idx, &mut Q[*j], &mut q_sizes[*j]);
+                                 }
+                             }
+                         };
+                     );
 
-                     for j in &[0, 2] {
-                         let idx = h(*j, ki.hash, block_length);
-                         H[*j][idx].mask ^= ki.hash;
-                         H[*j][idx].count -= 1;
-                         try_enqueue(&H[*j], idx, &mut Q[*j], &mut q_sizes[*j]);
-                     }
-                 }
+                     dequeue!(block 0, other blocks being 1, 2);
+                     dequeue!(block 1, other blocks being 0, 2);
+                     dequeue!(block 2, other blocks being 0, 1);
+                }
 
-                 while q_sizes[2] > 0 {
-                     q_sizes[2] -= 1;
-                     let mut ki = Q[2][q_sizes[2]];
-                     if H[2][ki.index].count == 0 {
-                         continue;
-                     }
-                     ki.index += 2 * block_length;
-                     stack[stack_size] = ki;
-                     stack_size += 1;
+                if stack_size == num_keys {
+                    break;
+                }
 
-                     for j in &[0, 1] {
-                         let idx = h(*j, ki.hash, block_length);
-                         H[*j][idx].mask ^= ki.hash;
-                         H[*j][idx].count -= 1;
-                         try_enqueue(&H[*j], idx, &mut Q[*j], &mut q_sizes[*j]);
-                     }
-                 }
-             }
+                // Filter failed to be created; reset and try again.
+                for block in H.iter_mut() {
+                    for set in block.iter_mut() {
+                        *set = HSet::default();
+                    }
+                }
+                seed = splitmix64(&mut rng)
+            }
 
-             if stack_size == num_keys {
-                 break;
-             }
+            // Construct all fingerprints (see Algorithm 4 in the paper).
+            #[allow(non_snake_case)]
+            let mut B = sets_block(capacity);
+            for ki in stack.iter().rev() {
+                B[ki.index] = fingerprint(ki.hash) as $fpty
+                    ^ B[h(0, ki.hash, block_length)]
+                    ^ B[(h(1, ki.hash, block_length) + block_length)]
+                    ^ B[(h(2, ki.hash, block_length) + 2 * block_length)];
+            }
 
-             // Filter failed to be created; reset and try again.
-             for block in H.iter_mut() {
-                 for set in block.iter_mut() {
-                     *set = HSet::default();
-                 }
-             }
-             seed = splitmix64(&mut rng)
-         }
-
-         // Construct all fingerprints (see Algorithm 4 in the paper).
-         #[allow(non_snake_case)]
-         let mut B = sets_block(capacity);
-         for ki in stack.iter().rev() {
-             B[ki.index] = fingerprint(ki.hash) as $fpty
-                 ^ B[h(0, ki.hash, block_length)]
-                 ^ B[(h(1, ki.hash, block_length) + block_length)]
-                 ^ B[(h(2, ki.hash, block_length) + 2 * block_length)];
-         }
-
-         Self {
-             seed,
-             block_length,
-             fingerprints: B,
-         }
+            Self {
+                seed,
+                block_length,
+                fingerprints: B,
+            }
         }
     };
 );

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -217,6 +217,7 @@ macro_rules! from_impl(
                                 for j in &[$a, $b] {
                                     let idx = h!(index block *j, of length block_length, using ki.hash);
                                     H[*j][idx].mask ^= ki.hash;
+                                    assert!(H[*j][idx].count != 0, "block {}, queue block size {}", $block, q_sizes[$block]);
                                     H[*j][idx].count -= 1;
                                     try_enqueue!(block H[*j], set #idx;
                                                  on queue block Q[*j], of size q_sizes[*j]);

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,291 @@
+//! Common methods for xor filters.
+
+use crate::murmur3;
+
+/// A set of hashes indexing three blocks.
+pub struct HashSet {
+    /// Key hash
+    pub hash: u64,
+    /// Indexing hashes h_0, h_1, h_2 created with `hash`.
+    pub hset: [usize; 3],
+}
+
+impl HashSet {
+    #[inline]
+    pub const fn from(key: u64, block_length: usize, seed: u64) -> Self {
+        let hash = mix(key, seed);
+
+        Self {
+            hash,
+            hset: [
+                crate::h!(index block 0, of length block_length, using hash),
+                crate::h!(index block 1, of length block_length, using hash),
+                crate::h!(index block 2, of length block_length, using hash),
+            ],
+        }
+    }
+}
+
+/// Applies a finalization mix to a randomly-seeded key, resulting in an avalanched hash. This
+/// helps avoid high false-positive ratios (see Section 4 in the paper).
+#[inline]
+const fn mix(key: u64, seed: u64) -> u64 {
+    murmur3::mix64(key.overflowing_add(seed).0)
+}
+
+/// The hash of a key and the index of that key in the construction array H.
+#[derive(Copy, Clone)]
+pub struct KeyIndex {
+    pub hash: u64,
+    pub index: usize,
+}
+
+/// A set in the construction array H. Elements are encoded via xor with the mask.
+#[derive(Default)]
+pub struct HSet {
+    pub count: u32,
+    pub mask: u64,
+}
+
+/// Computes a fingerprint.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! fingerprint(
+    ($hash:expr) => {
+        $hash ^ ($hash >> 32)
+    };
+);
+
+/// Rotate left
+#[doc(hidden)]
+#[macro_export]
+macro_rules! rotl64(
+    ($n:expr, by $c:expr) => {
+        ($n << ($c & 63)) | ($n >> ((-$c) & 63))
+    };
+);
+
+/// [A fast alternative to the modulo reduction](http://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/)
+#[doc(hidden)]
+#[macro_export]
+macro_rules! reduce(
+    ($hash:ident on interval $n:expr) => {
+        (($hash as u64 * $n as u64) >> 32) as usize
+    };
+);
+
+/// Computes a hash indexing the i'th filter block.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! h(
+    (index block $i:expr, of length $block_length:expr, using $hash:expr) => {
+        {
+            let rot = $crate::rotl64!($hash, by (($i as isize) * 21)) as u32; // shift hash to correct block interval
+            $crate::reduce!(rot on interval $block_length)
+        }
+    };
+);
+
+/// Creates a block of sets, each set being of type T.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! make_block(
+    ($num:ident sets of $T:ty) => {
+        {
+            let mut sets_block: Vec<$T> = Vec::with_capacity($num);
+            unsafe {
+                sets_block.set_len($num);
+            }
+            sets_block.into_boxed_slice()
+        }
+    };
+);
+
+/// Enqueues a set from the temporary construction array H if the set contains only one key.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! try_enqueue(
+    (block $H_block:expr, set #$idx:expr; on queue block $Q_block:expr, of size $Qblock_size:expr) => {
+        if $H_block[$idx].count == 1 {
+            $Q_block[$Qblock_size].index = $idx;
+            // If there is only one key, the mask contains it wholly.
+            $Q_block[$Qblock_size].hash = $H_block[$idx].mask;
+            $Qblock_size += 1;
+        }
+    };
+);
+
+/// Creates a `contains(u64)` implementation for an xor filter of fingerprint type `$fpty`.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! contains_impl(
+    ($key:ident, $self:expr, fingerprint $fpty:ty) => {
+        {
+            use $crate::prelude::HashSet;
+
+            let HashSet {
+                hash,
+                hset: [h0, h1, h2],
+            } = HashSet::from($key, $self.block_length, $self.seed);
+            let fp = $crate::fingerprint!(hash) as $fpty;
+
+            fp == $self.fingerprints[h0]
+                ^ $self.fingerprints[(h1 + $self.block_length)]
+                ^ $self.fingerprints[(h2 + 2 * $self.block_length)]
+        }
+    };
+);
+
+/// Creates an `from(&[u64])` implementation for an xor filter of fingerprint type `$fpty`.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! from_impl(
+    ($keys:ident fingerprint $fpty:ty) => {
+        {
+            use $crate::{
+                fingerprint,
+                h,
+                make_block,
+                prelude::{HashSet, HSet, KeyIndex},
+                splitmix64::splitmix64,
+                try_enqueue,
+            };
+
+            // See Algorithm 3 in the paper.
+            let num_keys = $keys.len();
+            let capacity = (1.23 * num_keys as f64) as usize + 32;
+            let capacity = capacity / 3 * 3; // round to nearest multiple of 3
+            let block_length = capacity / 3;
+
+            #[allow(non_snake_case)]
+            let mut H: [Box<[HSet]>; 3] = [
+                make_block!(capacity sets of HSet),
+                make_block!(capacity sets of HSet),
+                make_block!(capacity sets of HSet),
+            ];
+            #[allow(non_snake_case)]
+            let mut Q: [Box<[KeyIndex]>; 3] = [
+                make_block!(capacity sets of KeyIndex),
+                make_block!(capacity sets of KeyIndex),
+                make_block!(capacity sets of KeyIndex),
+            ];
+            let mut stack: Box<[KeyIndex]> = make_block!(capacity sets of KeyIndex);
+
+            let mut rng = 1;
+            let mut seed = splitmix64(&mut rng);
+            loop {
+                // Populate H by adding each key to its respective set.
+                for key in $keys.iter() {
+                    let HashSet { hash, hset } = HashSet::from(*key, block_length, seed);
+
+                    for b in 0..3 {
+                        let setindex = hset[b];
+                        H[b][setindex].mask ^= hash;
+                        H[b][setindex].count += 1;
+                    }
+                }
+
+                // Scan for sets with a single key. Add these keys to the queue.
+                let mut q_sizes: [usize; 3] = [0, 0, 0];
+                for b in 0..3 {
+                    for idx in 0..(block_length) {
+                        try_enqueue!(block H[b], set #idx;
+                                     on queue block Q[b], of size q_sizes[b]);
+                    }
+                }
+
+                let mut stack_size = 0;
+                while q_sizes.iter().sum::<usize>() > 0 {
+                    while q_sizes[0] > 0 {
+                        // Remove an element from the queue.
+                        q_sizes[0] -= 1;
+                        let ki = Q[0][q_sizes[0]];
+                        if H[0][ki.index].count == 0 {
+                            continue;
+                        }
+                        // If it's the only element in its respective set in H, add it to the output
+                        // stack.
+                        stack[stack_size] = ki;
+                        stack_size += 1;
+
+                        // Remove the element from every other set and enqueue any sets that now only
+                        // have one element.
+                        for j in &[1, 2] {
+                            let idx = h!(index block *j, of length block_length, using ki.hash);
+                            H[*j][idx].mask ^= ki.hash;
+                            H[*j][idx].count -= 1;
+                            try_enqueue!(block H[*j], set #idx;
+                                         on queue block Q[*j], of size q_sizes[*j]);
+                        }
+                    }
+
+                    while q_sizes[1] > 0 {
+                        q_sizes[1] -= 1;
+                        let mut ki = Q[1][q_sizes[1]];
+                        if H[1][ki.index].count == 0 {
+                            continue;
+                        }
+                        ki.index += block_length;
+                        stack[stack_size] = ki;
+                        stack_size += 1;
+
+                        for j in &[0, 2] {
+                            let idx = h!(index block *j, of length block_length, using ki.hash);
+                            H[*j][idx].mask ^= ki.hash;
+                            H[*j][idx].count -= 1;
+                            try_enqueue!(block H[*j], set #idx;
+                                         on queue block Q[*j], of size q_sizes[*j]);
+                        }
+                    }
+
+                    while q_sizes[2] > 0 {
+                        q_sizes[2] -= 1;
+                        let mut ki = Q[2][q_sizes[2]];
+                        if H[2][ki.index].count == 0 {
+                            continue;
+                        }
+                        ki.index += 2 * block_length;
+                        stack[stack_size] = ki;
+                        stack_size += 1;
+
+                        for j in &[0, 1] {
+                            let idx = h!(index block *j, of length block_length, using ki.hash);
+                            H[*j][idx].mask ^= ki.hash;
+                            H[*j][idx].count -= 1;
+                            try_enqueue!(block H[*j], set #idx;
+                                         on queue block Q[*j], of size q_sizes[*j]);
+                        }
+                    }
+                }
+
+                if stack_size == num_keys {
+                    break;
+                }
+
+                // Filter failed to be created; reset and try again.
+                for block in H.iter_mut() {
+                    for set in block.iter_mut() {
+                        *set = HSet::default();
+                    }
+                }
+                seed = splitmix64(&mut rng)
+            }
+
+            // Construct all fingerprints (see Algorithm 4 in the paper).
+            #[allow(non_snake_case)]
+            let mut B = make_block!(capacity sets of $fpty);
+            for ki in stack.iter().rev() {
+                B[ki.index] = fingerprint!(ki.hash) as $fpty
+                    ^ B[h!(index block 0, of length block_length, using ki.hash)]
+                    ^ B[(h!(index block 1, of length block_length, using ki.hash) + block_length)]
+                    ^ B[(h!(index block 2, of length block_length, using ki.hash) + 2 * block_length)];
+            }
+
+            Self {
+                seed,
+                block_length,
+                fingerprints: B,
+            }
+        }
+    };
+);

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -189,7 +189,7 @@ macro_rules! from_impl(
                 let mut q_sizes: [usize; 3] = [0, 0, 0];
                 for b in 0..3 {
                     for idx in 0..(block_length) {
-                        try_enqueue!(block &H[b], set idx;
+                        try_enqueue!(block H[b], set idx;
                                      queue block Q[b], with size q_sizes[b]);
                     }
                 }
@@ -218,7 +218,7 @@ macro_rules! from_impl(
                                     let idx = h!(index block *j, of length block_length, using ki.hash);
                                     H[*j][idx].mask ^= ki.hash;
                                     H[*j][idx].count -= 1;
-                                    try_enqueue!(block &H[*j], set idx;
+                                    try_enqueue!(block H[*j], set idx;
                                                  queue block Q[*j], with size q_sizes[*j]);
                                 }
                             }

--- a/src/xor16.rs
+++ b/src/xor16.rs
@@ -2,78 +2,11 @@
 //!
 //! [Xor Filters: Faster and Smaller Than Bloom and Cuckoo Filters]: https://arxiv.org/abs/1912.08258
 
-use crate::{murmur3, splitmix64::splitmix64, Filter};
+use crate::{contains_impl, from_impl, Filter};
 use alloc::{boxed::Box, vec::Vec};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-
-/// A set of hashes indexing three blocks.
-struct HashSet {
-    /// Key hash
-    hash: u64,
-    /// Indexing hashes h_0, h_1, h_2 created with `hash`.
-    hset: [usize; 3],
-}
-
-impl HashSet {
-    pub const fn from(key: u64, block_length: usize, seed: u64) -> Self {
-        let hash = mix(key, seed);
-
-        Self {
-            hash,
-            hset: [
-                h(0, hash, block_length),
-                h(1, hash, block_length),
-                h(2, hash, block_length),
-            ],
-        }
-    }
-}
-
-/// The hash of a key and the index of that key in the construction array H.
-#[derive(Copy, Clone)]
-struct KeyIndex {
-    hash: u64,
-    index: usize,
-}
-
-/// A set in the construction array H. Elements are encoded via xor with the mask.
-#[derive(Default)]
-struct HSet {
-    count: u32,
-    mask: u64,
-}
-
-/// Applies a finalization mix to a randomly-seeded key, resulting in an avalanched hash. This
-/// helps avoid high false-positive ratios (see Section 4 in the paper).
-#[inline]
-const fn mix(key: u64, seed: u64) -> u64 {
-    murmur3::mix64(key.overflowing_add(seed).0)
-}
-
-#[inline]
-const fn rotl64(n: u64, c: isize) -> u64 {
-    (n << (c & 63)) | (n >> ((-c) & 63))
-}
-
-/// [A fast alternative to the modulo reduction](http://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/)
-#[inline]
-const fn reduce(hash: u32, n: usize) -> usize {
-    ((hash as u64 * n as u64) >> 32) as usize
-}
-
-/// Computes a hash indexing the i'th filter block.
-#[inline]
-const fn h(i: usize, hash: u64, block_length: usize) -> usize {
-    let rot = rotl64(hash, (i as isize) * 21) as u32; // shift hash to correct block interval
-    reduce(rot, block_length)
-}
-
-#[inline]
-const fn fingerprint(hash: u64) -> u64 {
-    hash ^ (hash >> 32)
-}
 
 /// Xor filter using 16-bit fingerprints.
 ///
@@ -125,15 +58,7 @@ pub struct Xor16 {
 impl Filter for Xor16 {
     /// Returns `true` if the filter contains the specified key. Has a false positive rate of <0.02%.
     fn contains(&self, key: u64) -> bool {
-        let HashSet {
-            hash,
-            hset: [h0, h1, h2],
-        } = HashSet::from(key, self.block_length, self.seed);
-        let fp = fingerprint(hash) as u16;
-
-        fp == self.fingerprints[h0]
-            ^ self.fingerprints[(h1 + self.block_length)]
-            ^ self.fingerprints[(h2 + 2 * self.block_length)]
+        contains_impl!(key, &self, fingerprint u16)
     }
 
     fn len(&self) -> usize {
@@ -141,166 +66,9 @@ impl Filter for Xor16 {
     }
 }
 
-/// Creates a block of sets, each set being of type T.
-#[inline]
-fn sets_block<T>(size: usize) -> Box<[T]> {
-    let mut sets_block = Vec::with_capacity(size);
-    unsafe {
-        sets_block.set_len(size);
-    }
-    sets_block.into_boxed_slice()
-}
-
-/// Enqueues a set from the temporary construction array H if the set contains only one key.
-#[allow(non_snake_case)]
-#[inline]
-fn try_enqueue_set(
-    H_block: &[HSet],
-    idx: usize,
-    Q_block: &mut [KeyIndex],
-    qblock_size: &mut usize,
-) {
-    if H_block[idx].count == 1 {
-        Q_block[*qblock_size].index = idx;
-        // If there is only one key, the mask contains it wholly.
-        Q_block[*qblock_size].hash = H_block[idx].mask;
-        *qblock_size += 1;
-    }
-}
-
 impl From<&[u64]> for Xor16 {
     fn from(keys: &[u64]) -> Self {
-        // See Algorithm 3 in the paper.
-        let num_keys = keys.len();
-        let capacity = (1.23 * num_keys as f64) as usize + 32;
-        let capacity = capacity / 3 * 3; // round to nearest multiple of 3
-        let block_length = capacity / 3;
-
-        #[allow(non_snake_case)]
-        let mut Q: [Box<[KeyIndex]>; 3] = [
-            sets_block(capacity),
-            sets_block(capacity),
-            sets_block(capacity),
-        ];
-        #[allow(non_snake_case)]
-        let mut H: [Box<[HSet]>; 3] = [
-            sets_block(capacity),
-            sets_block(capacity),
-            sets_block(capacity),
-        ];
-        let mut stack: Box<[KeyIndex]> = sets_block(num_keys);
-
-        let mut rng = 1;
-        let mut seed = splitmix64(&mut rng);
-        loop {
-            // Populate H by adding each key to its respective set.
-            for key in keys.iter() {
-                let HashSet { hash, hset } = HashSet::from(*key, block_length, seed);
-
-                for b in 0..3 {
-                    let setindex = hset[b];
-                    H[b][setindex].mask ^= hash;
-                    H[b][setindex].count += 1;
-                }
-            }
-
-            // Scan for sets with a single key. Add these keys to the queue.
-            let mut q_sizes: [usize; 3] = [0, 0, 0];
-            for b in 0..3 {
-                for idx in 0..(block_length) {
-                    try_enqueue_set(&H[b], idx, &mut Q[b], &mut q_sizes[b]);
-                }
-            }
-
-            let mut stack_size = 0;
-            while q_sizes.iter().sum::<usize>() > 0 {
-                while q_sizes[0] > 0 {
-                    // Remove an element from the queue.
-                    q_sizes[0] -= 1;
-                    let ki = Q[0][q_sizes[0]];
-                    if H[0][ki.index].count == 0 {
-                        continue;
-                    }
-                    // If it's the only element in its respective set in H, add it to the output
-                    // stack.
-                    stack[stack_size] = ki;
-                    stack_size += 1;
-
-                    // Remove the element from every other set and enqueue any sets that now only
-                    // have one element.
-                    for j in &[1, 2] {
-                        let idx = h(*j, ki.hash, block_length);
-                        H[*j][idx].mask ^= ki.hash;
-                        H[*j][idx].count -= 1;
-                        try_enqueue_set(&H[*j], idx, &mut Q[*j], &mut q_sizes[*j]);
-                    }
-                }
-
-                while q_sizes[1] > 0 {
-                    q_sizes[1] -= 1;
-                    let mut ki = Q[1][q_sizes[1]];
-                    if H[1][ki.index].count == 0 {
-                        continue;
-                    }
-                    ki.index += block_length;
-                    stack[stack_size] = ki;
-                    stack_size += 1;
-
-                    for j in &[0, 2] {
-                        let idx = h(*j, ki.hash, block_length);
-                        H[*j][idx].mask ^= ki.hash;
-                        H[*j][idx].count -= 1;
-                        try_enqueue_set(&H[*j], idx, &mut Q[*j], &mut q_sizes[*j]);
-                    }
-                }
-
-                while q_sizes[2] > 0 {
-                    q_sizes[2] -= 1;
-                    let mut ki = Q[2][q_sizes[2]];
-                    if H[2][ki.index].count == 0 {
-                        continue;
-                    }
-                    ki.index += 2 * block_length;
-                    stack[stack_size] = ki;
-                    stack_size += 1;
-
-                    for j in &[0, 1] {
-                        let idx = h(*j, ki.hash, block_length);
-                        H[*j][idx].mask ^= ki.hash;
-                        H[*j][idx].count -= 1;
-                        try_enqueue_set(&H[*j], idx, &mut Q[*j], &mut q_sizes[*j]);
-                    }
-                }
-            }
-
-            if stack_size == num_keys {
-                break;
-            }
-
-            // Filter failed to be created; reset and try again.
-            for block in H.iter_mut() {
-                for set in block.iter_mut() {
-                    *set = HSet::default();
-                }
-            }
-            seed = splitmix64(&mut rng)
-        }
-
-        // Construct all fingerprints (see Algorithm 4 in the paper).
-        #[allow(non_snake_case)]
-        let mut B = sets_block(capacity);
-        for ki in stack.iter().rev() {
-            B[ki.index] = fingerprint(ki.hash) as u16
-                ^ B[h(0, ki.hash, block_length)]
-                ^ B[(h(1, ki.hash, block_length) + block_length)]
-                ^ B[(h(2, ki.hash, block_length) + 2 * block_length)];
-        }
-
-        Self {
-            seed,
-            block_length,
-            fingerprints: B,
-        }
+        from_impl!(keys fingerprint u16)
     }
 }
 

--- a/src/xor16.rs
+++ b/src/xor16.rs
@@ -58,7 +58,7 @@ pub struct Xor16 {
 impl Filter for Xor16 {
     /// Returns `true` if the filter contains the specified key. Has a false positive rate of <0.02%.
     fn contains(&self, key: u64) -> bool {
-        contains_impl!(key, &self, fingerprint u16)
+        contains_impl!(key, self, fingerprint u16)
     }
 
     fn len(&self) -> usize {

--- a/src/xor8.rs
+++ b/src/xor8.rs
@@ -58,7 +58,7 @@ pub struct Xor8 {
 impl Filter for Xor8 {
     /// Returns `true` if the filter contains the specified key. Has a false positive rate of <0.4%.
     fn contains(&self, key: u64) -> bool {
-        contains_impl!(key, &self, fingerprint u8)
+        contains_impl!(key, self, fingerprint u8)
     }
 
     fn len(&self) -> usize {

--- a/src/xor8.rs
+++ b/src/xor8.rs
@@ -2,78 +2,11 @@
 //!
 //! [Xor Filters: Faster and Smaller Than Bloom and Cuckoo Filters]: https://arxiv.org/abs/1912.08258
 
-use crate::{murmur3, splitmix64::splitmix64, Filter};
+use crate::{contains_impl, from_impl, Filter};
 use alloc::{boxed::Box, vec::Vec};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-
-/// A set of hashes indexing three blocks.
-struct HashSet {
-    /// Key hash
-    hash: u64,
-    /// Indexing hashes h_0, h_1, h_2 created with `hash`.
-    hset: [usize; 3],
-}
-
-impl HashSet {
-    pub const fn from(key: u64, block_length: usize, seed: u64) -> Self {
-        let hash = mix(key, seed);
-
-        Self {
-            hash,
-            hset: [
-                h(0, hash, block_length),
-                h(1, hash, block_length),
-                h(2, hash, block_length),
-            ],
-        }
-    }
-}
-
-/// The hash of a key and the index of that key in the construction array H.
-#[derive(Copy, Clone)]
-struct KeyIndex {
-    hash: u64,
-    index: usize,
-}
-
-/// A set in the construction array H. Elements are encoded via xor with the mask.
-#[derive(Default)]
-struct HSet {
-    count: u32,
-    mask: u64,
-}
-
-/// Applies a finalization mix to a randomly-seeded key, resulting in an avalanched hash. This
-/// helps avoid high false-positive ratios (see Section 4 in the paper).
-#[inline]
-const fn mix(key: u64, seed: u64) -> u64 {
-    murmur3::mix64(key.overflowing_add(seed).0)
-}
-
-#[inline]
-const fn rotl64(n: u64, c: isize) -> u64 {
-    (n << (c & 63)) | (n >> ((-c) & 63))
-}
-
-/// [A fast alternative to the modulo reduction](http://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/)
-#[inline]
-const fn reduce(hash: u32, n: usize) -> usize {
-    ((hash as u64 * n as u64) >> 32) as usize
-}
-
-/// Computes a hash indexing the i'th filter block.
-#[inline]
-const fn h(i: usize, hash: u64, block_length: usize) -> usize {
-    let rot = rotl64(hash, (i as isize) * 21) as u32; // shift hash to correct block interval
-    reduce(rot, block_length)
-}
-
-#[inline]
-const fn fingerprint(hash: u64) -> u64 {
-    hash ^ (hash >> 32)
-}
 
 /// Xor filter using 8-bit fingerprints.
 ///
@@ -125,15 +58,7 @@ pub struct Xor8 {
 impl Filter for Xor8 {
     /// Returns `true` if the filter contains the specified key. Has a false positive rate of <0.4%.
     fn contains(&self, key: u64) -> bool {
-        let HashSet {
-            hash,
-            hset: [h0, h1, h2],
-        } = HashSet::from(key, self.block_length, self.seed);
-        let fp = fingerprint(hash) as u8;
-
-        fp == self.fingerprints[h0]
-            ^ self.fingerprints[(h1 + self.block_length)]
-            ^ self.fingerprints[(h2 + 2 * self.block_length)]
+        contains_impl!(key, &self, fingerprint u8)
     }
 
     fn len(&self) -> usize {
@@ -141,166 +66,9 @@ impl Filter for Xor8 {
     }
 }
 
-/// Creates a block of sets, each set being of type T.
-#[inline]
-fn sets_block<T>(size: usize) -> Box<[T]> {
-    let mut sets_block = Vec::with_capacity(size);
-    unsafe {
-        sets_block.set_len(size);
-    }
-    sets_block.into_boxed_slice()
-}
-
-/// Enqueues a set from the temporary construction array H if the set contains only one key.
-#[allow(non_snake_case)]
-#[inline]
-fn try_enqueue_set(
-    H_block: &[HSet],
-    idx: usize,
-    Q_block: &mut [KeyIndex],
-    qblock_size: &mut usize,
-) {
-    if H_block[idx].count == 1 {
-        Q_block[*qblock_size].index = idx;
-        // If there is only one key, the mask contains it wholly.
-        Q_block[*qblock_size].hash = H_block[idx].mask;
-        *qblock_size += 1;
-    }
-}
-
 impl From<&[u64]> for Xor8 {
     fn from(keys: &[u64]) -> Self {
-        // See Algorithm 3 in the paper.
-        let num_keys = keys.len();
-        let capacity = (1.23 * num_keys as f64) as usize + 32;
-        let capacity = capacity / 3 * 3; // round to nearest multiple of 3
-        let block_length = capacity / 3;
-
-        #[allow(non_snake_case)]
-        let mut Q: [Box<[KeyIndex]>; 3] = [
-            sets_block(capacity),
-            sets_block(capacity),
-            sets_block(capacity),
-        ];
-        #[allow(non_snake_case)]
-        let mut H: [Box<[HSet]>; 3] = [
-            sets_block(capacity),
-            sets_block(capacity),
-            sets_block(capacity),
-        ];
-        let mut stack: Box<[KeyIndex]> = sets_block(num_keys);
-
-        let mut rng = 1;
-        let mut seed = splitmix64(&mut rng);
-        loop {
-            // Populate H by adding each key to its respective set.
-            for key in keys.iter() {
-                let HashSet { hash, hset } = HashSet::from(*key, block_length, seed);
-
-                for b in 0..3 {
-                    let setindex = hset[b];
-                    H[b][setindex].mask ^= hash;
-                    H[b][setindex].count += 1;
-                }
-            }
-
-            // Scan for sets with a single key. Add these keys to the queue.
-            let mut q_sizes: [usize; 3] = [0, 0, 0];
-            for b in 0..3 {
-                for idx in 0..(block_length) {
-                    try_enqueue_set(&H[b], idx, &mut Q[b], &mut q_sizes[b]);
-                }
-            }
-
-            let mut stack_size = 0;
-            while q_sizes.iter().sum::<usize>() > 0 {
-                while q_sizes[0] > 0 {
-                    // Remove an element from the queue.
-                    q_sizes[0] -= 1;
-                    let ki = Q[0][q_sizes[0]];
-                    if H[0][ki.index].count == 0 {
-                        continue;
-                    }
-                    // If it's the only element in its respective set in H, add it to the output
-                    // stack.
-                    stack[stack_size] = ki;
-                    stack_size += 1;
-
-                    // Remove the element from every other set and enqueue any sets that now only
-                    // have one element.
-                    for j in &[1, 2] {
-                        let idx = h(*j, ki.hash, block_length);
-                        H[*j][idx].mask ^= ki.hash;
-                        H[*j][idx].count -= 1;
-                        try_enqueue_set(&H[*j], idx, &mut Q[*j], &mut q_sizes[*j]);
-                    }
-                }
-
-                while q_sizes[1] > 0 {
-                    q_sizes[1] -= 1;
-                    let mut ki = Q[1][q_sizes[1]];
-                    if H[1][ki.index].count == 0 {
-                        continue;
-                    }
-                    ki.index += block_length;
-                    stack[stack_size] = ki;
-                    stack_size += 1;
-
-                    for j in &[0, 2] {
-                        let idx = h(*j, ki.hash, block_length);
-                        H[*j][idx].mask ^= ki.hash;
-                        H[*j][idx].count -= 1;
-                        try_enqueue_set(&H[*j], idx, &mut Q[*j], &mut q_sizes[*j]);
-                    }
-                }
-
-                while q_sizes[2] > 0 {
-                    q_sizes[2] -= 1;
-                    let mut ki = Q[2][q_sizes[2]];
-                    if H[2][ki.index].count == 0 {
-                        continue;
-                    }
-                    ki.index += 2 * block_length;
-                    stack[stack_size] = ki;
-                    stack_size += 1;
-
-                    for j in &[0, 1] {
-                        let idx = h(*j, ki.hash, block_length);
-                        H[*j][idx].mask ^= ki.hash;
-                        H[*j][idx].count -= 1;
-                        try_enqueue_set(&H[*j], idx, &mut Q[*j], &mut q_sizes[*j]);
-                    }
-                }
-            }
-
-            if stack_size == num_keys {
-                break;
-            }
-
-            // Filter failed to be created; reset and try again.
-            for block in H.iter_mut() {
-                for set in block.iter_mut() {
-                    *set = HSet::default();
-                }
-            }
-            seed = splitmix64(&mut rng)
-        }
-
-        // Construct all fingerprints (see Algorithm 4 in the paper).
-        #[allow(non_snake_case)]
-        let mut B = sets_block(capacity);
-        for ki in stack.iter().rev() {
-            B[ki.index] = fingerprint(ki.hash) as u8
-                ^ B[h(0, ki.hash, block_length)]
-                ^ B[(h(1, ki.hash, block_length) + block_length)]
-                ^ B[(h(2, ki.hash, block_length) + 2 * block_length)];
-        }
-
-        Self {
-            seed,
-            block_length,
-            fingerprints: B,
-        }
+        from_impl!(keys fingerprint u8)
     }
 }
 


### PR DESCRIPTION
Applies macros to implementations of the `from` and `contains` methods
for the current filters. This harms readability but should significantly
improve performance, as everything becomes inlined at compile time.