### PR TITLE
e: support try_from fuse filter creation

### DIFF
--- a/benches/fuse16.rs
+++ b/benches/fuse16.rs
@@ -1,8 +1,10 @@
 #[macro_use]
 extern crate criterion;
+extern crate core;
 extern crate rand;
 extern crate xorf;
 
+use core::convert::TryFrom;
 use criterion::{BenchmarkId, Criterion};
 use rand::Rng;
 use xorf::{Filter, Fuse16};
@@ -17,7 +19,7 @@ fn from(c: &mut Criterion) {
     let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
 
     group.bench_with_input(BenchmarkId::new("from", SAMPLE_SIZE), &keys, |b, keys| {
-        b.iter(|| Fuse16::from(keys));
+        b.iter(|| Fuse16::try_from(keys).unwrap());
     });
 }
 
@@ -26,7 +28,7 @@ fn contains(c: &mut Criterion) {
 
     let mut rng = rand::thread_rng();
     let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
-    let filter = Fuse16::from(&keys);
+    let filter = Fuse16::try_from(&keys).unwrap();
 
     group.bench_function(BenchmarkId::new("contains", SAMPLE_SIZE), |b| {
         let key = rng.gen();

--- a/benches/fuse8.rs
+++ b/benches/fuse8.rs
@@ -1,8 +1,10 @@
 #[macro_use]
 extern crate criterion;
+extern crate core;
 extern crate rand;
 extern crate xorf;
 
+use core::convert::TryFrom;
 use criterion::{BenchmarkId, Criterion};
 use rand::Rng;
 use xorf::{Filter, Fuse8};
@@ -17,7 +19,7 @@ fn from(c: &mut Criterion) {
     let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
 
     group.bench_with_input(BenchmarkId::new("from", SAMPLE_SIZE), &keys, |b, keys| {
-        b.iter(|| Fuse8::from(keys));
+        b.iter(|| Fuse8::try_from(keys).unwrap());
     });
 }
 
@@ -26,7 +28,7 @@ fn contains(c: &mut Criterion) {
 
     let mut rng = rand::thread_rng();
     let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
-    let filter = Fuse8::from(&keys);
+    let filter = Fuse8::try_from(&keys).unwrap();
 
     group.bench_function(BenchmarkId::new("contains", SAMPLE_SIZE), |b| {
         let key = rng.gen();

--- a/src/fuse16.rs
+++ b/src/fuse16.rs
@@ -2,6 +2,7 @@
 
 use crate::{fuse_contains_impl, fuse_from_impl, Filter};
 use alloc::{boxed::Box, vec::Vec};
+use core::convert::TryFrom;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -14,20 +15,22 @@ use serde::{Deserialize, Serialize};
 ///
 /// A `Fuse16` filter uses less space and is faster to construct than an [`Xor16`] filter, but
 /// requires a large number of keys to be constructed. Experimentally, this number is somewhere
-/// >100_000. For smaller key sets, prefer the [`Xor16`] filter.
+/// >100_000. For smaller key sets, prefer the [`Xor16`] filter. A `Fuse16` filter may fail to be
+/// constructed.
 ///
 /// A `Fuse16` is constructed from a set of 64-bit unsigned integers and is immutable.
 ///
 /// ```
 /// # extern crate alloc;
 /// use xorf::{Filter, Fuse16};
+/// use core::convert::TryFrom;
 /// # use alloc::vec::Vec;
 /// # use rand::Rng;
 ///
 /// # let mut rng = rand::thread_rng();
 /// const SAMPLE_SIZE: usize = 1_000_000;
 /// let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
-/// let filter = Fuse16::from(&keys);
+/// let filter = Fuse16::try_from(&keys).unwrap();
 ///
 /// // no false negatives
 /// for key in keys {
@@ -53,6 +56,7 @@ use serde::{Deserialize, Serialize};
 /// [`Xor16`]: crate::Xor16
 /// [`serde`]: http://serde.rs
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug)]
 pub struct Fuse16 {
     seed: u64,
     segment_length: usize,
@@ -70,21 +74,26 @@ impl Filter for Fuse16 {
     }
 }
 
-impl From<&[u64]> for Fuse16 {
-    fn from(keys: &[u64]) -> Self {
-        fuse_from_impl!(keys fingerprint u16)
+impl TryFrom<&[u64]> for Fuse16 {
+    type Error = &'static str;
+
+    fn try_from(keys: &[u64]) -> Result<Self, Self::Error> {
+        fuse_from_impl!(keys fingerprint u16, max iter 1_000)
     }
 }
 
-impl From<&Vec<u64>> for Fuse16 {
-    fn from(v: &Vec<u64>) -> Self {
-        Self::from(v.as_slice())
+impl TryFrom<&Vec<u64>> for Fuse16 {
+    type Error = &'static str;
+
+    fn try_from(v: &Vec<u64>) -> Result<Self, Self::Error> {
+        Self::try_from(v.as_slice())
     }
 }
 
 #[cfg(test)]
 mod test {
     use crate::{Filter, Fuse16};
+    use core::convert::TryFrom;
 
     use alloc::vec::Vec;
     use rand::Rng;
@@ -95,7 +104,7 @@ mod test {
         let mut rng = rand::thread_rng();
         let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
 
-        let filter = Fuse16::from(&keys);
+        let filter = Fuse16::try_from(&keys).unwrap();
 
         for key in keys {
             assert!(filter.contains(key));
@@ -108,7 +117,7 @@ mod test {
         let mut rng = rand::thread_rng();
         let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
 
-        let filter = Fuse16::from(&keys);
+        let filter = Fuse16::try_from(&keys).unwrap();
         let bpe = (filter.len() as f64) * 16.0 / (SAMPLE_SIZE as f64);
 
         assert!(bpe < 18.202, "Bits per entry is {}", bpe);
@@ -120,7 +129,7 @@ mod test {
         let mut rng = rand::thread_rng();
         let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
 
-        let filter = Fuse16::from(&keys);
+        let filter = Fuse16::try_from(&keys).unwrap();
 
         let false_positives: usize = (0..SAMPLE_SIZE)
             .map(|_| rng.gen())
@@ -128,5 +137,15 @@ mod test {
             .count();
         let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;
         assert!(fp_rate < 0.02, "False positive rate is {}", fp_rate);
+    }
+
+    #[test]
+    fn test_fail_construction() {
+        const SAMPLE_SIZE: usize = 1_000;
+        let mut rng = rand::thread_rng();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+
+        let filter = Fuse16::try_from(&keys);
+        assert!(filter.expect_err("") == "Failed to construct fuse filter.");
     }
 }


### PR DESCRIPTION
This commit adds support for `TryFrom` for fuse filters, which may fail
to be constructed for small set sizes.