### PR TITLE
e: type filter trait with generic type

### DIFF
--- a/benches/fuse16.rs
+++ b/benches/fuse16.rs
@@ -30,7 +30,7 @@ fn contains(c: &mut Criterion) {
 
     group.bench_function(BenchmarkId::new("contains", SAMPLE_SIZE), |b| {
         let key = rng.gen();
-        b.iter(|| filter.contains(key));
+        b.iter(|| filter.contains(&key));
     });
 }
 

--- a/benches/fuse8.rs
+++ b/benches/fuse8.rs
@@ -30,7 +30,7 @@ fn contains(c: &mut Criterion) {
 
     group.bench_function(BenchmarkId::new("contains", SAMPLE_SIZE), |b| {
         let key = rng.gen();
-        b.iter(|| filter.contains(key));
+        b.iter(|| filter.contains(&key));
     });
 }
 

--- a/benches/xor16.rs
+++ b/benches/xor16.rs
@@ -30,7 +30,7 @@ fn contains(c: &mut Criterion) {
 
     group.bench_function(BenchmarkId::new("contains", SAMPLE_SIZE), |b| {
         let key = rng.gen();
-        b.iter(|| filter.contains(key));
+        b.iter(|| filter.contains(&key));
     });
 }
 

--- a/benches/xor8.rs
+++ b/benches/xor8.rs
@@ -30,7 +30,7 @@ fn contains(c: &mut Criterion) {
 
     group.bench_function(BenchmarkId::new("contains", SAMPLE_SIZE), |b| {
         let key = rng.gen();
-        b.iter(|| filter.contains(key));
+        b.iter(|| filter.contains(&key));
     });
 }
 

--- a/src/fuse16.rs
+++ b/src/fuse16.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// // no false negatives
 /// for key in keys {
-///     assert!(filter.contains(key));
+///     assert!(filter.contains(&key));
 /// }
 ///
 /// // bits per entry
@@ -41,7 +41,7 @@ use serde::{Deserialize, Serialize};
 /// // false positive rate
 /// let false_positives: usize = (0..SAMPLE_SIZE)
 ///     .map(|_| rng.gen())
-///     .filter(|n| filter.contains(*n))
+///     .filter(|n| filter.contains(n))
 ///     .count();
 /// let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;
 /// assert!(fp_rate < 0.02, "False positive rate is {}", fp_rate);
@@ -59,10 +59,10 @@ pub struct Fuse16 {
     fingerprints: Box<[u16]>,
 }
 
-impl Filter for Fuse16 {
+impl Filter<u64> for Fuse16 {
     /// Returns `true` if the filter contains the specified key. Has a false positive rate of <0.02%.
-    fn contains(&self, key: u64) -> bool {
-        fuse_contains_impl!(key, self, fingerprint u16)
+    fn contains(&self, key: &u64) -> bool {
+        fuse_contains_impl!(*key, self, fingerprint u16)
     }
 
     fn len(&self) -> usize {
@@ -98,7 +98,7 @@ mod test {
         let filter = Fuse16::from(&keys);
 
         for key in keys {
-            assert!(filter.contains(key));
+            assert!(filter.contains(&key));
         }
     }
 
@@ -124,7 +124,7 @@ mod test {
 
         let false_positives: usize = (0..SAMPLE_SIZE)
             .map(|_| rng.gen())
-            .filter(|n| filter.contains(*n))
+            .filter(|n| filter.contains(n))
             .count();
         let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;
         assert!(fp_rate < 0.02, "False positive rate is {}", fp_rate);

--- a/src/fuse8.rs
+++ b/src/fuse8.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// // no false negatives
 /// for key in keys {
-///     assert!(filter.contains(key));
+///     assert!(filter.contains(&key));
 /// }
 ///
 /// // bits per entry
@@ -41,7 +41,7 @@ use serde::{Deserialize, Serialize};
 /// // false positive rate
 /// let false_positives: usize = (0..SAMPLE_SIZE)
 ///     .map(|_| rng.gen())
-///     .filter(|n| filter.contains(*n))
+///     .filter(|n| filter.contains(n))
 ///     .count();
 /// let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;
 /// assert!(fp_rate < 0.4, "False positive rate is {}", fp_rate);
@@ -59,10 +59,10 @@ pub struct Fuse8 {
     fingerprints: Box<[u8]>,
 }
 
-impl Filter for Fuse8 {
+impl Filter<u64> for Fuse8 {
     /// Returns `true` if the filter contains the specified key. Has a false positive rate of <0.4%.
-    fn contains(&self, key: u64) -> bool {
-        fuse_contains_impl!(key, self, fingerprint u8)
+    fn contains(&self, key: &u64) -> bool {
+        fuse_contains_impl!(*key, self, fingerprint u8)
     }
 
     fn len(&self) -> usize {
@@ -98,7 +98,7 @@ mod test {
         let filter = Fuse8::from(&keys);
 
         for key in keys {
-            assert!(filter.contains(key));
+            assert!(filter.contains(&key));
         }
     }
 
@@ -124,7 +124,7 @@ mod test {
 
         let false_positives: usize = (0..SAMPLE_SIZE)
             .map(|_| rng.gen())
-            .filter(|n| filter.contains(*n))
+            .filter(|n| filter.contains(n))
             .count();
         let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;
         assert!(fp_rate < 0.4, "False positive rate is {}", fp_rate);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,12 +49,12 @@ pub use xor16::Xor16;
 pub use xor8::Xor8;
 
 /// Methods common to xor filters.
-pub trait Filter {
+pub trait Filter<Type> {
     /// Returns `true` if the filter probably contains the specified key.
     ///
     /// There can never be a false negative, but there is a small possibility of false positives.
     /// Refer to individual filters' documentation for false positive rates.
-    fn contains(&self, key: u64) -> bool;
+    fn contains(&self, key: &Type) -> bool;
 
     /// Returns the number of fingerprints in the filter.
     fn len(&self) -> usize;

--- a/src/prelude/fuse.rs
+++ b/src/prelude/fuse.rs
@@ -47,7 +47,7 @@ impl H012 {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! fuse_contains_impl(
-    ($key:ident, $self:expr, fingerprint $fpty:ty) => {
+    ($key:expr, $self:expr, fingerprint $fpty:ty) => {
         {
             use $crate::prelude::HashSet;
 

--- a/src/prelude/xor.rs
+++ b/src/prelude/xor.rs
@@ -32,7 +32,7 @@ macro_rules! xor_h(
 #[doc(hidden)]
 #[macro_export]
 macro_rules! xor_contains_impl(
-    ($key:ident, $self:expr, fingerprint $fpty:ty) => {
+    ($key:expr, $self:expr, fingerprint $fpty:ty) => {
         {
             use $crate::prelude::HashSet;
 

--- a/src/xor16.rs
+++ b/src/xor16.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// // no false negatives
 /// for key in keys {
-///     assert!(filter.contains(key));
+///     assert!(filter.contains(&key));
 /// }
 ///
 /// // bits per entry
@@ -39,7 +39,7 @@ use serde::{Deserialize, Serialize};
 /// // false positive rate
 /// let false_positives: usize = (0..SAMPLE_SIZE)
 ///     .map(|_| rng.gen())
-///     .filter(|n| filter.contains(*n))
+///     .filter(|n| filter.contains(n))
 ///     .count();
 /// let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;
 /// assert!(fp_rate < 0.02, "False positive rate is {}", fp_rate);
@@ -55,10 +55,10 @@ pub struct Xor16 {
     fingerprints: Box<[u16]>,
 }
 
-impl Filter for Xor16 {
+impl Filter<u64> for Xor16 {
     /// Returns `true` if the filter contains the specified key. Has a false positive rate of <0.02%.
-    fn contains(&self, key: u64) -> bool {
-        xor_contains_impl!(key, self, fingerprint u16)
+    fn contains(&self, key: &u64) -> bool {
+        xor_contains_impl!(*key, self, fingerprint u16)
     }
 
     fn len(&self) -> usize {
@@ -94,7 +94,7 @@ mod test {
         let filter = Xor16::from(&keys);
 
         for key in keys {
-            assert!(filter.contains(key));
+            assert!(filter.contains(&key));
         }
     }
 
@@ -120,7 +120,7 @@ mod test {
 
         let false_positives: usize = (0..SAMPLE_SIZE)
             .map(|_| rng.gen())
-            .filter(|n| filter.contains(*n))
+            .filter(|n| filter.contains(n))
             .count();
         let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;
         assert!(fp_rate < 0.02, "False positive rate is {}", fp_rate);

--- a/src/xor8.rs
+++ b/src/xor8.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// // no false negatives
 /// for key in keys {
-///     assert!(filter.contains(key));
+///     assert!(filter.contains(&key));
 /// }
 ///
 /// // bits per entry
@@ -39,7 +39,7 @@ use serde::{Deserialize, Serialize};
 /// // false positive rate
 /// let false_positives: usize = (0..SAMPLE_SIZE)
 ///     .map(|_| rng.gen())
-///     .filter(|n| filter.contains(*n))
+///     .filter(|n| filter.contains(n))
 ///     .count();
 /// let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;
 /// assert!(fp_rate < 0.405, "False positive rate is {}", fp_rate);
@@ -55,10 +55,10 @@ pub struct Xor8 {
     fingerprints: Box<[u8]>,
 }
 
-impl Filter for Xor8 {
+impl Filter<u64> for Xor8 {
     /// Returns `true` if the filter contains the specified key. Has a false positive rate of <0.4%.
-    fn contains(&self, key: u64) -> bool {
-        xor_contains_impl!(key, self, fingerprint u8)
+    fn contains(&self, key: &u64) -> bool {
+        xor_contains_impl!(*key, self, fingerprint u8)
     }
 
     fn len(&self) -> usize {
@@ -94,7 +94,7 @@ mod test {
         let filter = Xor8::from(&keys);
 
         for key in keys {
-            assert!(filter.contains(key));
+            assert!(filter.contains(&key));
         }
     }
 
@@ -120,7 +120,7 @@ mod test {
 
         let false_positives: usize = (0..SAMPLE_SIZE)
             .map(|_| rng.gen())
-            .filter(|n| filter.contains(*n))
+            .filter(|n| filter.contains(n))
             .count();
         let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;
         assert!(fp_rate < 0.405, "False positive rate is {}", fp_rate);


### PR DESCRIPTION
To support [arbitrary filter key types](#10), Xor filters should be
defined as being able to accept any key type. Since this key may
potentially be expensive to manufacture, checking for its existence in
the filter should require only a borrow.

This commit redefines the `Filter` trait to take any key type and
updates existing filters accordingly. A future commit will add a hasing
filter with support for arbitrary key types, backed by a `u64` Xor
filter.