### PR TITLE
e: add HashProxy for Xor filters

### DIFF
--- a/src/fuse16.rs
+++ b/src/fuse16.rs
@@ -90,6 +90,14 @@ impl TryFrom<&Vec<u64>> for Fuse16 {
     }
 }
 
+impl TryFrom<Vec<u64>> for Fuse16 {
+    type Error = &'static str;
+
+    fn try_from(v: Vec<u64>) -> Result<Self, Self::Error> {
+        Self::try_from(v.as_slice())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::{Filter, Fuse16};

--- a/src/fuse8.rs
+++ b/src/fuse8.rs
@@ -90,6 +90,14 @@ impl TryFrom<&Vec<u64>> for Fuse8 {
     }
 }
 
+impl TryFrom<Vec<u64>> for Fuse8 {
+    type Error = &'static str;
+
+    fn try_from(v: Vec<u64>) -> Result<Self, Self::Error> {
+        Self::try_from(v.as_slice())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::{Filter, Fuse8};

--- a/src/hash_proxy.rs
+++ b/src/hash_proxy.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 ///     .map(|_| rng.sample_iter(&Alphanumeric).take(30).collect())
 ///     .collect();
 ///
-/// let pw_filter: HashProxy<DefaultHasher, Xor8> = HashProxy::from(&passwords);
+/// let pw_filter: HashProxy<_, DefaultHasher, Xor8> = HashProxy::from(&passwords);
 ///
 /// for password in passwords {
 ///     assert!(pw_filter.contains(&password));

--- a/src/hash_proxy.rs
+++ b/src/hash_proxy.rs
@@ -175,15 +175,13 @@ mod test {
             .collect();
 
         macro_rules! drive_test {
-            ($xorf:ident) => {
-                {
-                    let keys = keys.clone();
-                    let filter: HashProxy<_, DefaultHasher, $xorf> = HashProxy::from(&keys);
-                    for key in keys {
-                        assert!(filter.contains(&key));
-                    }
+            ($xorf:ident) => {{
+                let keys = keys.clone();
+                let filter: HashProxy<_, DefaultHasher, $xorf> = HashProxy::from(&keys);
+                for key in keys {
+                    assert!(filter.contains(&key));
                 }
-            }
+            }};
         }
 
         drive_test!(Xor8);

--- a/src/hash_proxy.rs
+++ b/src/hash_proxy.rs
@@ -1,0 +1,167 @@
+//! Implements a hashing proxy for Xor filters.
+
+use crate::Filter;
+use alloc::vec::Vec;
+use core::hash::{Hash, Hasher};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// Hashing proxy for Xor filters.
+///
+/// A `HashProxy` exposes a [`Filter`] trait for arbitrary key types, using a `Filter<u64>` as
+/// an underlying keystore. The performance and collision rate of the `HashProxy` filter depends
+/// on the choice of [`Hasher`] and underlying [`Filter`]. A `HashProxy` is immutable once
+/// constructed.
+///
+/// ```
+/// # extern crate alloc;
+/// # extern crate std;
+/// use std::collections::hash_map::DefaultHasher;
+/// use xorf::{Filter, HashProxy, Xor8};
+/// # use alloc::vec::Vec;
+/// # use rand::distributions::Alphanumeric;
+/// # use rand::Rng;
+///
+/// const SAMPLE_SIZE: usize = 1_000_000;
+/// let rng = rand::thread_rng();
+/// let passwords: Vec<String> = (0..SAMPLE_SIZE)
+///     .map(|_| rng.sample_iter(&Alphanumeric).take(30).collect())
+///     .collect();
+///
+/// let pw_filter: HashProxy<DefaultHasher, Xor8> = HashProxy::from(&passwords);
+///
+/// for password in passwords {
+///     assert!(pw_filter.contains(&password));
+/// }
+/// ```
+///
+/// A `HashProxy` persists type data about the underlying keystore. This means that the existence
+/// of a key can only be checked using types the `HashProxy` was created with.
+///
+/// ```compile_fail
+/// # extern crate alloc;
+/// # extern crate std;
+/// use std::collections::hash_map::DefaultHasher;
+/// use std::hash::{Hash, Hasher};
+/// use xorf::{Filter, HashProxy, Xor8};
+/// # use alloc::vec::Vec;
+///
+/// let fruits = vec!["apple", "banana", "tangerine", "watermelon"];
+/// let fruits: HashProxy<_, DefaultHasher, Xor8> = HashProxy::from(&fruits);
+///
+/// let mut hasher = DefaultHasher::default();
+/// "tangerine".hash(&mut hasher);
+/// let tangerine_hash = hasher.finish();
+///
+/// assert!(fruits.contains(&tangerine_hash)); // doesn't work!
+/// ```
+///
+/// Serializing and deserializing `HashProxy`s can be enabled with the [`serde`] feature.
+///
+/// [`Filter`]: crate::Filter
+/// [`Hasher`]: core::hash::Hasher
+/// [`serde`]: http://serde.rs
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct HashProxy<T, H, F>
+where
+    T: Hash,
+    H: Hasher + Default,
+    F: Filter<u64>,
+{
+    filter: F,
+    _hasher: core::marker::PhantomData<H>,
+    _type: core::marker::PhantomData<T>,
+}
+
+#[inline]
+fn hash<T: Hash, H: Hasher + Default>(key: &T) -> u64 {
+    let mut hasher = H::default();
+    key.hash(&mut hasher);
+    hasher.finish()
+}
+
+impl<T, H, F> Filter<T> for HashProxy<T, H, F>
+where
+    T: Hash,
+    H: Hasher + Default,
+    F: Filter<u64>,
+{
+    /// Returns `true` if the underlying filter contains the specified key.
+    fn contains(&self, key: &T) -> bool {
+        self.filter.contains(&hash::<T, H>(key))
+    }
+
+    fn len(&self) -> usize {
+        self.filter.len()
+    }
+}
+
+impl<T, H, F> From<&[T]> for HashProxy<T, H, F>
+where
+    T: Hash,
+    H: Hasher + Default,
+    F: Filter<u64> + From<Vec<u64>>,
+{
+    fn from(keys: &[T]) -> Self {
+        let keys: Vec<u64> = keys.iter().map(hash::<T, H>).collect();
+        Self {
+            filter: F::from(keys),
+            _hasher: core::marker::PhantomData,
+            _type: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<T, H, F> From<&Vec<T>> for HashProxy<T, H, F>
+where
+    T: Hash,
+    H: Hasher + Default,
+    F: Filter<u64> + From<Vec<u64>>,
+{
+    fn from(v: &Vec<T>) -> Self {
+        Self::from(v.as_slice())
+    }
+}
+
+// TODO(ayazhafiz): We should support a `TryFrom` trait as well. Today this is impossible due to
+// rustc's core blanket implementation of `Into`, which picks up a conflicting implementation when
+// both `From<T>` and `TryFrom<T>` with unbound type parameters `T` are defined.
+//
+// See https://github.com/rust-lang/rust/issues/50133 for more details.
+
+#[cfg(test)]
+mod test {
+    use crate::{xor16::Xor16, xor8::Xor8};
+    use crate::{Filter, HashProxy};
+
+    use alloc::vec::Vec;
+    use rand::distributions::Alphanumeric;
+    use rand::Rng;
+
+    extern crate std;
+    use std::collections::hash_map::DefaultHasher;
+    use std::string::String;
+
+    #[test]
+    fn test_initialization_from() {
+        macro_rules! test {
+            ($xorf:ident) => {{
+                const SAMPLE_SIZE: usize = 1_000_000;
+                let rng = rand::thread_rng();
+                let keys: Vec<String> = (0..SAMPLE_SIZE)
+                    .map(|_| rng.sample_iter(&Alphanumeric).take(30).collect())
+                    .collect();
+
+                let filter: HashProxy<_, DefaultHasher, $xorf> = HashProxy::from(&keys);
+
+                for key in keys {
+                    assert!(filter.contains(&key));
+                }
+            }};
+        }
+
+        test!(Xor8);
+        test!(Xor16);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,11 +43,13 @@ mod splitmix64;
 
 mod fuse16;
 mod fuse8;
+mod hash_proxy;
 mod xor16;
 mod xor8;
 
 pub use fuse16::Fuse16;
 pub use fuse8::Fuse8;
+pub use hash_proxy::HashProxy;
 pub use xor16::Xor16;
 pub use xor8::Xor8;
 

--- a/src/xor16.rs
+++ b/src/xor16.rs
@@ -78,6 +78,12 @@ impl From<&Vec<u64>> for Xor16 {
     }
 }
 
+impl From<Vec<u64>> for Xor16 {
+    fn from(v: Vec<u64>) -> Self {
+        Self::from(v.as_slice())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::{Filter, Xor16};

--- a/src/xor8.rs
+++ b/src/xor8.rs
@@ -78,6 +78,12 @@ impl From<&Vec<u64>> for Xor8 {
     }
 }
 
+impl From<Vec<u64>> for Xor8 {
+    fn from(v: Vec<u64>) -> Self {
+        Self::from(v.as_slice())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::{Filter, Xor8};


### PR DESCRIPTION
Xor filters only support 64-bit unsigned integer keys, but there is
often a need to provide a filter for other data types (a common example
would be recording string URLs in a rapid-access filter). `xorf` would
like to support arbitrary data type filters, but decouple them from the
functionality of Xor filters, which should stay as only supporting
64-bit unsigned integers for performance reasons. This commit adds a
`HashingProxy` for constructing filters of an arbitrary data type using
a `Filter` as underlying keystore.