### PR TITLE
Set unused fingerprint entries to random values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-/target
+target
 **/*.rs.bk
 Cargo.lock
+zeroes.txt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,13 @@ repository = "ayazhafiz/xorf"
 
 [dependencies]
 serde = { version = "1.0.104", optional = true, features = ["derive"] }
+num-traits = { version = "0.2.12", optional = true }
+rand = { version = "0.7.3", optional = true }
 
 [dev-dependencies]
 criterion = "0.3.0"
 criterion-macro = "0.3.0"
-rand = "0.7.2"
+rand = "0.7.3"
 
 [[bench]]
 name = "fuse16"
@@ -50,3 +52,8 @@ harness = false
 [[bench]]
 name = "xor8"
 harness = false
+
+[features]
+default = ["uniform-random"]
+uniform-random = ["rand"]
+analysis = ["num-traits"]

--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ Add a dependency to `xorf` in `Cargo.toml`:
 xorf = "M.m.p" # use a desired version
 ```
 
+Available versions are listed on [crates](https://crates.io/crates/xorf) and the in [repository's
+releases](https://github.com/ayazhafiz/xorf/releases).
+
+## Usage
+
+Please see the [library documentation](https://docs.rs/xorf) for usage
+information.
+
+### Features
+
 To enable
 [`needs_allocator`](https://doc.rust-lang.org/1.9.0/book/custom-allocators.html)
 and serialization/deserialization, add the `nightly` and `serde` features,
@@ -54,16 +64,16 @@ respectively:
 xorf = { version = "M.m.p", features = ["nightly", "serde"] }
 ```
 
-Finally, add `xorf` as an external crate in the depender crate's root file:
+By default, `xorf` uses the `uniform-random` feature, which uses random values for unused
+fingerprint entries rather than setting them to zero. This provides a slightly lower false-positive
+rate, but incurs a higher initialization cost. The cost of lookups is not affected.
 
-```rust
-extern crate xorf;
+To disable the `uniform-random` feature, specify that default features should be disabled:
+
+```toml
+[dependencies]
+xorf = { version = "M.m.p", default-features = false }
 ```
-
-## Usage
-
-Please see the [library documentation](https://docs.rs/xorf) for usage
-information.
 
 ## Development
 

--- a/analysis/Cargo.toml
+++ b/analysis/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "xorf-analysis"
+version = "0.0.0"
+authors = []
+publish = false
+edition = "2018"
+
+[[bin]]
+name = "zeroes"
+path = "src/zeroes.rs"
+
+[dependencies]
+rand = "0.7.3"
+
+[dependencies.xorf]
+path = ".."
+features = ["analysis"]

--- a/analysis/plot_zeroes
+++ b/analysis/plot_zeroes
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Plots the distribution of zeroes in a filter.
+#
+# Usage:
+#     plot_zeroes <Xor8|Xor16|Fuse8|Fuse16>
+#
+# Dependencies:
+#     pip install matplotlib
+
+cargo run -q zeroes -- "$1" > zeroes.txt
+python plot_zeroes.py

--- a/analysis/plot_zeroes.py
+++ b/analysis/plot_zeroes.py
@@ -1,0 +1,11 @@
+# See analysis/plot_zeroes
+
+import matplotlib.pyplot as plt
+
+with open('zeroes.txt', 'r') as f:
+    x = [int(v) for v in f.readlines()]
+
+plt.xlabel('Sample')
+plt.ylabel('Zeroes in 2000 element window')
+plt.plot(x)
+plt.show()

--- a/analysis/src/zeroes.rs
+++ b/analysis/src/zeroes.rs
@@ -1,0 +1,52 @@
+// See analysis/plot_zeroes
+
+extern crate core;
+extern crate rand;
+extern crate xorf;
+
+use core::convert::TryFrom;
+use rand::Rng;
+use xorf::*;
+
+const SIZE: usize = 7_000_000;
+
+macro_rules! print_zeroes {
+    ($filter:ident) => {{
+        let mut keys: Vec<u64> = Vec::with_capacity(SIZE);
+
+        for _ in 0..SIZE {
+            let key: u64 = rand::thread_rng().gen();
+            keys.push(key);
+        }
+        let filter = $filter::try_from(keys).unwrap();
+        let fp = filter.fingerprints();
+        let window_size = 2000;
+        let mut zeroes: usize = 0;
+        for (i, t) in fp.iter().enumerate() {
+            if *t == 0 {
+                zeroes += 1;
+            }
+            if i > window_size && fp[i - window_size] == 0 {
+                zeroes -= 1;
+            }
+            if i > window_size && i % 333 == 0 {
+                println!("{}", zeroes);
+            }
+        }
+    }};
+}
+
+fn main() {
+    let filter_str = std::env::args()
+        .collect::<Vec<_>>()
+        .pop()
+        .expect("Expected filter argument");
+
+    match filter_str.as_ref() {
+        "Fuse8" => print_zeroes!(Fuse8),
+        "Fuse16" => print_zeroes!(Fuse16),
+        "Xor8" => print_zeroes!(Xor8),
+        "Xor16" => print_zeroes!(Xor16),
+        _ => panic!("Filter {} is invalid", filter_str),
+    };
+}

--- a/src/fuse16.rs
+++ b/src/fuse16.rs
@@ -72,6 +72,14 @@ impl Filter<u64> for Fuse16 {
     fn len(&self) -> usize {
         self.fingerprints.len()
     }
+
+    #[cfg(feature = "analysis")]
+    type N = u16;
+
+    #[cfg(feature = "analysis")]
+    fn fingerprints(&self) -> &[Self::N] {
+        &self.fingerprints
+    }
 }
 
 impl TryFrom<&[u64]> for Fuse16 {

--- a/src/fuse8.rs
+++ b/src/fuse8.rs
@@ -72,6 +72,14 @@ impl Filter<u64> for Fuse8 {
     fn len(&self) -> usize {
         self.fingerprints.len()
     }
+
+    #[cfg(feature = "analysis")]
+    type N = u8;
+
+    #[cfg(feature = "analysis")]
+    fn fingerprints(&self) -> &[Self::N] {
+        &self.fingerprints
+    }
 }
 
 impl TryFrom<&[u64]> for Fuse8 {

--- a/src/hash_proxy.rs
+++ b/src/hash_proxy.rs
@@ -117,6 +117,14 @@ where
     fn len(&self) -> usize {
         self.filter.len()
     }
+
+    #[cfg(feature = "analysis")]
+    type N = F::N;
+
+    #[cfg(feature = "analysis")]
+    fn fingerprints(&self) -> &[Self::N] {
+        self.filter.fingerprints()
+    }
 }
 
 impl<T, H, F> From<&[T]> for HashProxy<T, H, F>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,9 @@ mod hash_proxy;
 mod xor16;
 mod xor8;
 
+#[cfg(feature = "analysis")]
+use num_traits::Unsigned;
+
 pub use fuse16::Fuse16;
 pub use fuse8::Fuse8;
 pub use hash_proxy::HashProxy;
@@ -65,4 +68,12 @@ pub trait Filter<Type> {
 
     /// Returns the number of fingerprints in the filter.
     fn len(&self) -> usize;
+
+    /// Type of the fingerprints used in the filter.
+    #[cfg(feature = "analysis")]
+    type N: Unsigned;
+
+    /// Returns the list of fingerprints used by the filter.
+    #[cfg(feature = "analysis")]
+    fn fingerprints(&self) -> &[Self::N];
 }

--- a/src/prelude/mod.rs
+++ b/src/prelude/mod.rs
@@ -73,6 +73,36 @@ macro_rules! make_block(
     };
 );
 
+/// Creates a block to store output fingerprints.
+/// This is distinguished from `make_block`, as we may want to randomize the unused fingerprints
+/// rather than making them all 0.
+///
+/// ## Why?
+///
+/// Inevitably some fingerprint entries will not be used. If all of these unused entries are 0,
+/// then the false-positive rate for a element x where fingerprint(x) = 0 is significantly higher
+/// than if the unused entries are uniformly random
+///
+/// Of course, the tradeoff here is that generating random elements is more expensive than
+/// memsetting a bunch of zeroes, so the option is configurable with the `uniform-random` feature.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! make_fp_block(
+    ($size:ident) => {
+        if cfg!(feature = "uniform-random") {
+            use rand::Rng;
+            let mut rng = rand::thread_rng();
+            let mut block = Vec::with_capacity($size);
+            for _ in 0..$size {
+                block.push(rng.gen());
+            }
+            block.into_boxed_slice()
+        } else {
+            make_block!(with $size sets)
+        }
+    }
+);
+
 /// Creates a block of sets, each set being of type T.
 #[doc(hidden)]
 #[macro_export]

--- a/src/xor16.rs
+++ b/src/xor16.rs
@@ -64,6 +64,14 @@ impl Filter<u64> for Xor16 {
     fn len(&self) -> usize {
         self.fingerprints.len()
     }
+
+    #[cfg(feature = "analysis")]
+    type N = u16;
+
+    #[cfg(feature = "analysis")]
+    fn fingerprints(&self) -> &[Self::N] {
+        &self.fingerprints
+    }
 }
 
 impl From<&[u64]> for Xor16 {

--- a/src/xor8.rs
+++ b/src/xor8.rs
@@ -64,6 +64,14 @@ impl Filter<u64> for Xor8 {
     fn len(&self) -> usize {
         self.fingerprints.len()
     }
+
+    #[cfg(feature = "analysis")]
+    type N = u8;
+
+    #[cfg(feature = "analysis")]
+    fn fingerprints(&self) -> &[Self::N] {
+        &self.fingerprints
+    }
 }
 
 impl From<&[u64]> for Xor8 {


### PR DESCRIPTION
This slightly reduces the false-positive rate of entry lookups compared
to when unused entries are set to 0. For a Fuse8 filter, the
false-positive rate drops from ~0.39% to ~0.37%.

The commit also exposes an analysis module for measuring the
distribution of zeroes in a filter, thanks to @rot256's insights in #16.

Closes #16

cc @rot256