### PR TITLE
make xor16 fields public

### DIFF
--- a/src/xor16.rs
+++ b/src/xor16.rs
@@ -50,9 +50,12 @@ use serde::{Deserialize, Serialize};
 /// [`serde`]: http://serde.rs
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Xor16 {
-    seed: u64,
-    block_length: usize,
-    fingerprints: Box<[u16]>,
+    /// The seed for the filter
+    pub seed: u64,
+    /// The number of blocks in the filter
+    pub block_length: usize,
+    /// The fingerprints for the filter
+    pub fingerprints: Box<[u16]>,
 }
 
 impl Filter<u64> for Xor16 {


### PR DESCRIPTION
Since the fields and their byte structure are well defined making them public makes constructing a filter from serialized forms a lot simpler