### PR TITLE
Fixes release build

### DIFF
--- a/src/prelude/mod.rs
+++ b/src/prelude/mod.rs
@@ -122,7 +122,6 @@ macro_rules! try_enqueue(
 );
 
 /// Checks if a collection of keys has all distinct values.
-#[cfg(debug_assertions)]
 pub fn all_distinct<'a>(keys: impl IntoIterator<Item = &'a u64>) -> bool {
     let mut s = alloc::collections::BTreeSet::new();
     keys.into_iter().all(move |x| s.insert(x))


### PR DESCRIPTION
Since all_distinct is used in `use prelude::` expressions the all_distinct function must be included in the build