### PR TITLE
fix #47: use overflow subtraction and addition to match Go implementation

### DIFF
--- a/src/bfuse8.rs
+++ b/src/bfuse8.rs
@@ -110,6 +110,16 @@ mod test {
     use rand::Rng;
 
     #[test]
+    fn test_zero_and_single() {
+        let keys = vec![];
+        let filter = BinaryFuse8::try_from(&keys).unwrap();
+
+        let keys = vec![1];
+        let filter = BinaryFuse8::try_from(&keys).unwrap();
+        // no panic
+    }
+
+    #[test]
     fn test_initialization() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
@@ -153,7 +163,7 @@ mod test {
     #[test]
     #[cfg(debug_assertions)]
     #[should_panic(
-        expected = "Binary Fuse filters must be constructed from a collection containing all distinct keys."
+    expected = "Binary Fuse filters must be constructed from a collection containing all distinct keys."
     )]
     fn test_debug_assert_duplicates() {
         let _ = BinaryFuse8::try_from(vec![1, 2, 1]);

--- a/src/prelude/bfuse.rs
+++ b/src/prelude/bfuse.rs
@@ -56,7 +56,7 @@ pub const fn mod3(x: u8) -> u8 {
 /// Implements `try_from(&[u64])` for an binary fuse filter of fingerprint type `$fpty`.
 #[doc(hidden)]
 #[macro_export]
-macro_rules! bfuse_from_impl(
+macro_rules! bfuse_from_impl (
     ($keys:ident fingerprint $fpty:ty, max iter $max_iter:expr) => {
         {
             use libm::round;
@@ -84,9 +84,10 @@ macro_rules! bfuse_from_impl(
             let capacity: u32 = if size > 1 {
                 round(size as f64 * size_factor) as u32
             } else { 0 };
-            let init_segment_count = (capacity + segment_length - 1) / segment_length - (arity - 1);
+            // rust implementation is a fork from golang implementation https://github.com/FastFilter/xorfilter/blob/master/binaryfusefilter.go#L57
+            let init_segment_count = ((capacity + segment_length - 1) / segment_length).overflowing_sub(arity - 1).0;
             let (fp_array_len, segment_count) = {
-                let array_len = (init_segment_count + arity - 1) * segment_length;
+                let array_len = init_segment_count.overflowing_add(arity - 1).0 * segment_length;
                 let segment_count: u32 = {
                     let proposed = (array_len + segment_length - 1) / segment_length;
                     if proposed < arity {
@@ -278,7 +279,7 @@ macro_rules! bfuse_from_impl(
 /// Implements `contains(u64)` for a binary fuse filter of fingerprint type `$fpty`.
 #[doc(hidden)]
 #[macro_export]
-macro_rules! bfuse_contains_impl(
+macro_rules! bfuse_contains_impl (
     ($key:expr, $self:expr, fingerprint $fpty:ty) => {
         {
             use $crate::{


### PR DESCRIPTION
Xorf's Go implementation executes with integer overflow sub/add operations. This PR matches the behavior in Rust

Ref: https://github.com/FastFilter/xorfilter/blob/master/binaryfusefilter.go#L57