### PR TITLE
Add from_iterator/try_from_iterator for the filters.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,11 +39,31 @@ criterion-macro = "0.3.0"
 rand = "0.8"
 
 [[bench]]
+name = "bfuse32"
+harness = false
+
+[[bench]]
+name = "bfuse16"
+harness = false
+
+[[bench]]
+name = "bfuse8"
+harness = false
+
+[[bench]]
+name = "fuse32"
+harness = false
+
+[[bench]]
 name = "fuse16"
 harness = false
 
 [[bench]]
 name = "fuse8"
+harness = false
+
+[[bench]]
+name = "xor32"
 harness = false
 
 [[bench]]

--- a/benches/bfuse16.rs
+++ b/benches/bfuse16.rs
@@ -1,0 +1,40 @@
+#[macro_use]
+extern crate criterion;
+extern crate core;
+extern crate rand;
+extern crate xorf;
+
+use core::convert::TryFrom;
+use criterion::{BenchmarkId, Criterion};
+use rand::Rng;
+use xorf::{Filter, BinaryFuse16};
+
+const SAMPLE_SIZE: u32 = 500_000;
+
+fn from(c: &mut Criterion) {
+    let mut group = c.benchmark_group("BinaryFuse16");
+    let group = group.sample_size(10);
+
+    let mut rng = rand::thread_rng();
+    let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+
+    group.bench_with_input(BenchmarkId::new("from", SAMPLE_SIZE), &keys, |b, keys| {
+        b.iter(|| BinaryFuse16::try_from(keys).unwrap());
+    });
+}
+
+fn contains(c: &mut Criterion) {
+    let mut group = c.benchmark_group("BinaryFuse16");
+
+    let mut rng = rand::thread_rng();
+    let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+    let filter = BinaryFuse16::try_from(&keys).unwrap();
+
+    group.bench_function(BenchmarkId::new("contains", SAMPLE_SIZE), |b| {
+        let key = rng.gen();
+        b.iter(|| filter.contains(&key));
+    });
+}
+
+criterion_group!(bfuse16, from, contains);
+criterion_main!(bfuse16);

--- a/benches/bfuse16.rs
+++ b/benches/bfuse16.rs
@@ -7,7 +7,7 @@ extern crate xorf;
 use core::convert::TryFrom;
 use criterion::{BenchmarkId, Criterion};
 use rand::Rng;
-use xorf::{Filter, BinaryFuse16};
+use xorf::{BinaryFuse16, Filter};
 
 const SAMPLE_SIZE: u32 = 500_000;
 

--- a/benches/bfuse32.rs
+++ b/benches/bfuse32.rs
@@ -7,7 +7,7 @@ extern crate xorf;
 use core::convert::TryFrom;
 use criterion::{BenchmarkId, Criterion};
 use rand::Rng;
-use xorf::{Filter, BinaryFuse32};
+use xorf::{BinaryFuse32, Filter};
 
 const SAMPLE_SIZE: u32 = 500_000;
 

--- a/benches/bfuse32.rs
+++ b/benches/bfuse32.rs
@@ -1,0 +1,40 @@
+#[macro_use]
+extern crate criterion;
+extern crate core;
+extern crate rand;
+extern crate xorf;
+
+use core::convert::TryFrom;
+use criterion::{BenchmarkId, Criterion};
+use rand::Rng;
+use xorf::{Filter, BinaryFuse32};
+
+const SAMPLE_SIZE: u32 = 500_000;
+
+fn from(c: &mut Criterion) {
+    let mut group = c.benchmark_group("BinaryFuse32");
+    let group = group.sample_size(10);
+
+    let mut rng = rand::thread_rng();
+    let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+
+    group.bench_with_input(BenchmarkId::new("from", SAMPLE_SIZE), &keys, |b, keys| {
+        b.iter(|| BinaryFuse32::try_from(keys).unwrap());
+    });
+}
+
+fn contains(c: &mut Criterion) {
+    let mut group = c.benchmark_group("BinaryFuse32");
+
+    let mut rng = rand::thread_rng();
+    let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+    let filter = BinaryFuse32::try_from(&keys).unwrap();
+
+    group.bench_function(BenchmarkId::new("contains", SAMPLE_SIZE), |b| {
+        let key = rng.gen();
+        b.iter(|| filter.contains(&key));
+    });
+}
+
+criterion_group!(bfuse32, from, contains);
+criterion_main!(bfuse32);

--- a/benches/bfuse8.rs
+++ b/benches/bfuse8.rs
@@ -1,0 +1,40 @@
+#[macro_use]
+extern crate criterion;
+extern crate core;
+extern crate rand;
+extern crate xorf;
+
+use core::convert::TryFrom;
+use criterion::{BenchmarkId, Criterion};
+use rand::Rng;
+use xorf::{BinaryFuse8, Filter};
+
+const SAMPLE_SIZE: u32 = 500_000;
+
+fn from(c: &mut Criterion) {
+    let mut group = c.benchmark_group("BinaryFuse8");
+    let group = group.sample_size(10);
+
+    let mut rng = rand::thread_rng();
+    let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+
+    group.bench_with_input(BenchmarkId::new("from", SAMPLE_SIZE), &keys, |b, keys| {
+        b.iter(|| BinaryFuse8::try_from(keys).unwrap());
+    });
+}
+
+fn contains(c: &mut Criterion) {
+    let mut group = c.benchmark_group("BinaryFuse8");
+
+    let mut rng = rand::thread_rng();
+    let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+    let filter = BinaryFuse8::try_from(&keys).unwrap();
+
+    group.bench_function(BenchmarkId::new("contains", SAMPLE_SIZE), |b| {
+        let key = rng.gen();
+        b.iter(|| filter.contains(&key));
+    });
+}
+
+criterion_group!(bfuse8, from, contains);
+criterion_main!(bfuse8);

--- a/benches/fuse32.rs
+++ b/benches/fuse32.rs
@@ -1,0 +1,40 @@
+#[macro_use]
+extern crate criterion;
+extern crate core;
+extern crate rand;
+extern crate xorf;
+
+use core::convert::TryFrom;
+use criterion::{BenchmarkId, Criterion};
+use rand::Rng;
+use xorf::{Filter, Fuse32};
+
+const SAMPLE_SIZE: u32 = 500_000;
+
+fn from(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Fuse32");
+    let group = group.sample_size(10);
+
+    let mut rng = rand::thread_rng();
+    let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+
+    group.bench_with_input(BenchmarkId::new("from", SAMPLE_SIZE), &keys, |b, keys| {
+        b.iter(|| Fuse32::try_from(keys).unwrap());
+    });
+}
+
+fn contains(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Fuse32");
+
+    let mut rng = rand::thread_rng();
+    let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+    let filter = Fuse32::try_from(&keys).unwrap();
+
+    group.bench_function(BenchmarkId::new("contains", SAMPLE_SIZE), |b| {
+        let key = rng.gen();
+        b.iter(|| filter.contains(&key));
+    });
+}
+
+criterion_group!(fuse32, from, contains);
+criterion_main!(fuse32);

--- a/benches/xor32.rs
+++ b/benches/xor32.rs
@@ -1,0 +1,38 @@
+#[macro_use]
+extern crate criterion;
+extern crate rand;
+extern crate xorf;
+
+use criterion::{BenchmarkId, Criterion};
+use rand::Rng;
+use xorf::{Filter, Xor32};
+
+const SAMPLE_SIZE: u32 = 500_000;
+
+fn from(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Xor32");
+    let group = group.sample_size(10);
+
+    let mut rng = rand::thread_rng();
+    let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+
+    group.bench_with_input(BenchmarkId::new("from", SAMPLE_SIZE), &keys, |b, keys| {
+        b.iter(|| Xor32::from(keys));
+    });
+}
+
+fn contains(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Xor32");
+
+    let mut rng = rand::thread_rng();
+    let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+    let filter = Xor32::from(&keys);
+
+    group.bench_function(BenchmarkId::new("contains", SAMPLE_SIZE), |b| {
+        let key = rng.gen();
+        b.iter(|| filter.contains(&key));
+    });
+}
+
+criterion_group!(xor32, from, contains);
+criterion_main!(xor32);

--- a/src/bfuse16.rs
+++ b/src/bfuse16.rs
@@ -77,11 +77,26 @@ impl Filter<u64> for BinaryFuse16 {
     }
 }
 
+impl BinaryFuse16 {
+    /// Try to construct the filter from a key iterator. Can be used directly
+    /// if you don't have a contiguous array of u64 keys.
+    ///
+    /// Note: the iterator will be iterated over multiple times while building
+    /// the filter. If using a hash function to map the key, it may be cheaper
+    /// just to create a scratch array of hashed keys that you pass in.
+    pub fn try_from_iterator<T>(keys: T) -> Result<Self, &'static str>
+    where
+        T: ExactSizeIterator<Item = u64> + Clone,
+    {
+        bfuse_from_impl!(keys fingerprint u16, max iter 1_000)
+    }
+}
+
 impl TryFrom<&[u64]> for BinaryFuse16 {
     type Error = &'static str;
 
     fn try_from(keys: &[u64]) -> Result<Self, Self::Error> {
-        bfuse_from_impl!(keys fingerprint u16, max iter 1_000)
+        Self::try_from_iterator(keys.iter().copied())
     }
 }
 
@@ -89,7 +104,7 @@ impl TryFrom<&Vec<u64>> for BinaryFuse16 {
     type Error = &'static str;
 
     fn try_from(v: &Vec<u64>) -> Result<Self, Self::Error> {
-        Self::try_from(v.as_slice())
+        Self::try_from_iterator(v.iter().copied())
     }
 }
 
@@ -97,7 +112,7 @@ impl TryFrom<Vec<u64>> for BinaryFuse16 {
     type Error = &'static str;
 
     fn try_from(v: Vec<u64>) -> Result<Self, Self::Error> {
-        Self::try_from(v.as_slice())
+        Self::try_from_iterator(v.iter().copied())
     }
 }
 

--- a/src/bfuse32.rs
+++ b/src/bfuse32.rs
@@ -78,11 +78,26 @@ impl Filter<u64> for BinaryFuse32 {
     }
 }
 
+impl BinaryFuse32 {
+    /// Try to construct the filter from a key iterator. Can be used directly
+    /// if you don't have a contiguous array of u64 keys.
+    ///
+    /// Note: the iterator will be iterated over multiple times while building
+    /// the filter. If using a hash function to map the key, it may be cheaper
+    /// just to create a scratch array of hashed keys that you pass in.
+    pub fn try_from_iterator<T>(keys: T) -> Result<Self, &'static str>
+    where
+        T: ExactSizeIterator<Item = u64> + Clone,
+    {
+        bfuse_from_impl!(keys fingerprint u32, max iter 1_000)
+    }
+}
+
 impl TryFrom<&[u64]> for BinaryFuse32 {
     type Error = &'static str;
 
     fn try_from(keys: &[u64]) -> Result<Self, Self::Error> {
-        bfuse_from_impl!(keys fingerprint u32, max iter 1_000)
+        Self::try_from_iterator(keys.iter().copied())
     }
 }
 
@@ -90,7 +105,7 @@ impl TryFrom<&Vec<u64>> for BinaryFuse32 {
     type Error = &'static str;
 
     fn try_from(v: &Vec<u64>) -> Result<Self, Self::Error> {
-        Self::try_from(v.as_slice())
+        Self::try_from_iterator(v.iter().copied())
     }
 }
 
@@ -98,7 +113,7 @@ impl TryFrom<Vec<u64>> for BinaryFuse32 {
     type Error = &'static str;
 
     fn try_from(v: Vec<u64>) -> Result<Self, Self::Error> {
-        Self::try_from(v.as_slice())
+        Self::try_from_iterator(v.iter().copied())
     }
 }
 

--- a/src/bfuse8.rs
+++ b/src/bfuse8.rs
@@ -77,11 +77,26 @@ impl Filter<u64> for BinaryFuse8 {
     }
 }
 
+impl BinaryFuse8 {
+    /// Try to construct the filter from a key iterator. Can be used directly
+    /// if you don't have a contiguous array of u64 keys.
+    ///
+    /// Note: the iterator will be iterated over multiple times while building
+    /// the filter. If using a hash function to map the key, it may be cheaper
+    /// just to create a scratch array of hashed keys that you pass in.
+    pub fn try_from_iterator<T>(keys: T) -> Result<Self, &'static str>
+    where
+        T: ExactSizeIterator<Item = u64> + Clone,
+    {
+        bfuse_from_impl!(keys fingerprint u8, max iter 1_000)
+    }
+}
+
 impl TryFrom<&[u64]> for BinaryFuse8 {
     type Error = &'static str;
 
     fn try_from(keys: &[u64]) -> Result<Self, Self::Error> {
-        bfuse_from_impl!(keys fingerprint u8, max iter 1_000)
+        Self::try_from_iterator(keys.iter().copied())
     }
 }
 
@@ -89,7 +104,7 @@ impl TryFrom<&Vec<u64>> for BinaryFuse8 {
     type Error = &'static str;
 
     fn try_from(v: &Vec<u64>) -> Result<Self, Self::Error> {
-        Self::try_from(v.as_slice())
+        Self::try_from_iterator(v.iter().copied())
     }
 }
 
@@ -97,7 +112,7 @@ impl TryFrom<Vec<u64>> for BinaryFuse8 {
     type Error = &'static str;
 
     fn try_from(v: Vec<u64>) -> Result<Self, Self::Error> {
-        Self::try_from(v.as_slice())
+        Self::try_from_iterator(v.iter().copied())
     }
 }
 

--- a/src/fuse16.rs
+++ b/src/fuse16.rs
@@ -80,11 +80,26 @@ impl Filter<u64> for Fuse16 {
     }
 }
 
+impl Fuse16 {
+    /// Try to construct the filter from a key iterator. Can be used directly
+    /// if you don't have a contiguous array of u64 keys.
+    ///
+    /// Note: the iterator will be iterated over multiple times while building
+    /// the filter. If using a hash function to map the key, it may be cheaper
+    /// just to create a scratch array of hashed keys that you pass in.
+    pub fn try_from_iterator<T>(keys: T) -> Result<Self, &'static str>
+    where
+        T: ExactSizeIterator<Item = u64> + Clone,
+    {
+        fuse_from_impl!(keys fingerprint u16, max iter 1_000)
+    }
+}
+
 impl TryFrom<&[u64]> for Fuse16 {
     type Error = &'static str;
 
     fn try_from(keys: &[u64]) -> Result<Self, Self::Error> {
-        fuse_from_impl!(keys fingerprint u16, max iter 1_000)
+        Self::try_from_iterator(keys.iter().copied())
     }
 }
 
@@ -92,7 +107,7 @@ impl TryFrom<&Vec<u64>> for Fuse16 {
     type Error = &'static str;
 
     fn try_from(v: &Vec<u64>) -> Result<Self, Self::Error> {
-        Self::try_from(v.as_slice())
+        Self::try_from_iterator(v.iter().copied())
     }
 }
 
@@ -100,7 +115,7 @@ impl TryFrom<Vec<u64>> for Fuse16 {
     type Error = &'static str;
 
     fn try_from(v: Vec<u64>) -> Result<Self, Self::Error> {
-        Self::try_from(v.as_slice())
+        Self::try_from_iterator(v.iter().copied())
     }
 }
 

--- a/src/fuse32.rs
+++ b/src/fuse32.rs
@@ -80,11 +80,26 @@ impl Filter<u64> for Fuse32 {
     }
 }
 
+impl Fuse32 {
+    /// Try to construct the filter from a key iterator. Can be used directly
+    /// if you don't have a contiguous array of u64 keys.
+    ///
+    /// Note: the iterator will be iterated over multiple times while building
+    /// the filter. If using a hash function to map the key, it may be cheaper
+    /// just to create a scratch array of hashed keys that you pass in.
+    pub fn try_from_iterator<T>(keys: T) -> Result<Self, &'static str>
+    where
+        T: ExactSizeIterator<Item = u64> + Clone,
+    {
+        fuse_from_impl!(keys fingerprint u32, max iter 1_000)
+    }
+}
+
 impl TryFrom<&[u64]> for Fuse32 {
     type Error = &'static str;
 
     fn try_from(keys: &[u64]) -> Result<Self, Self::Error> {
-        fuse_from_impl!(keys fingerprint u32, max iter 1_000)
+        Self::try_from_iterator(keys.iter().copied())
     }
 }
 
@@ -92,7 +107,7 @@ impl TryFrom<&Vec<u64>> for Fuse32 {
     type Error = &'static str;
 
     fn try_from(v: &Vec<u64>) -> Result<Self, Self::Error> {
-        Self::try_from(v.as_slice())
+        Self::try_from_iterator(v.iter().copied())
     }
 }
 
@@ -100,7 +115,7 @@ impl TryFrom<Vec<u64>> for Fuse32 {
     type Error = &'static str;
 
     fn try_from(v: Vec<u64>) -> Result<Self, Self::Error> {
-        Self::try_from(v.as_slice())
+        Self::try_from_iterator(v.iter().copied())
     }
 }
 

--- a/src/fuse8.rs
+++ b/src/fuse8.rs
@@ -80,11 +80,26 @@ impl Filter<u64> for Fuse8 {
     }
 }
 
+impl Fuse8 {
+    /// Try to construct the filter from a key iterator. Can be used directly
+    /// if you don't have a contiguous array of u64 keys.
+    ///
+    /// Note: the iterator will be iterated over multiple times while building
+    /// the filter. If using a hash function to map the key, it may be cheaper
+    /// just to create a scratch array of hashed keys that you pass in.
+    pub fn try_from_iterator<T>(keys: T) -> Result<Self, &'static str>
+    where
+        T: ExactSizeIterator<Item = u64> + Clone,
+    {
+        fuse_from_impl!(keys fingerprint u8, max iter 1_000)
+    }
+}
+
 impl TryFrom<&[u64]> for Fuse8 {
     type Error = &'static str;
 
     fn try_from(keys: &[u64]) -> Result<Self, Self::Error> {
-        fuse_from_impl!(keys fingerprint u8, max iter 1_000)
+        Self::try_from_iterator(keys.iter().copied())
     }
 }
 
@@ -92,7 +107,7 @@ impl TryFrom<&Vec<u64>> for Fuse8 {
     type Error = &'static str;
 
     fn try_from(v: &Vec<u64>) -> Result<Self, Self::Error> {
-        Self::try_from(v.as_slice())
+        Self::try_from_iterator(v.iter().copied())
     }
 }
 
@@ -100,7 +115,7 @@ impl TryFrom<Vec<u64>> for Fuse8 {
     type Error = &'static str;
 
     fn try_from(v: Vec<u64>) -> Result<Self, Self::Error> {
-        Self::try_from(v.as_slice())
+        Self::try_from_iterator(v.iter().copied())
     }
 }
 

--- a/src/prelude/bfuse.rs
+++ b/src/prelude/bfuse.rs
@@ -73,7 +73,7 @@ macro_rules! bfuse_from_impl(
 
             #[cfg(debug_assertions)] {
                 use $crate::prelude::all_distinct;
-                debug_assert!(all_distinct($keys), "Binary Fuse filters must be constructed from a collection containing all distinct keys.");
+                debug_assert!(all_distinct($keys.clone()), "Binary Fuse filters must be constructed from a collection containing all distinct keys.");
             }
 
             let arity = 3u32;
@@ -130,8 +130,8 @@ macro_rules! bfuse_from_impl(
                 for i in 0..start_pos_len {
                     start_pos[i] = (((i as u64) * (size as u64)) >> block_bits) as usize;
                 }
-                for key in $keys.iter() {
-                    let hash = mix(*key, seed);
+                for key in $keys.clone() {
+                    let hash = mix(key, seed);
                     let mut segment_index = hash >> (64 - block_bits);
                     while reverse_order[start_pos[segment_index as usize] as usize] != 0 {
                         segment_index += 1;

--- a/src/prelude/fuse.rs
+++ b/src/prelude/fuse.rs
@@ -82,7 +82,7 @@ macro_rules! fuse_from_impl(
 
             #[cfg(debug_assertions)] {
                 use $crate::prelude::all_distinct;
-                debug_assert!(all_distinct($keys), "Fuse filters must be constructed from a collection containing all distinct keys.");
+                debug_assert!(all_distinct($keys.clone()), "Fuse filters must be constructed from a collection containing all distinct keys.");
             }
 
             // See Algorithm 3 in the paper.
@@ -102,8 +102,8 @@ macro_rules! fuse_from_impl(
             let mut done = false;
             for _ in 0..$max_iter {
                 // Populate H by adding each key to its respective set.
-                for key in $keys.iter() {
-                    let HashSet { hash, hset } = HashSet::fuse_from(*key, segment_length, seed);
+                for key in $keys.clone() {
+                    let HashSet { hash, hset } = HashSet::fuse_from(key, segment_length, seed);
 
                     for b in 0..3 {
                         H[hset[b]].mask ^= hash;

--- a/src/prelude/mod.rs
+++ b/src/prelude/mod.rs
@@ -125,7 +125,7 @@ macro_rules! try_enqueue(
 
 /// Checks if a collection of keys has all distinct values.
 #[cfg(debug_assertions)]
-pub fn all_distinct<'a>(keys: impl IntoIterator<Item = &'a u64>) -> bool {
+pub fn all_distinct(keys: impl IntoIterator<Item = u64>) -> bool {
     let mut s = alloc::collections::BTreeSet::new();
     keys.into_iter().all(move |x| s.insert(x))
 }

--- a/src/prelude/xor.rs
+++ b/src/prelude/xor.rs
@@ -65,7 +65,7 @@ macro_rules! xor_from_impl(
 
             #[cfg(debug_assertions)] {
                 use $crate::prelude::all_distinct;
-                debug_assert!(all_distinct($keys), "Xor filters must be constructed from a collection containing all distinct keys.");
+                debug_assert!(all_distinct($keys.clone()), "Xor filters must be constructed from a collection containing all distinct keys.");
             }
 
             // See Algorithm 3 in the paper.
@@ -92,8 +92,8 @@ macro_rules! xor_from_impl(
             let mut seed = splitmix64(&mut rng);
             loop {
                 // Populate H by adding each key to its respective set.
-                for key in $keys.iter() {
-                    let HashSet { hash, hset } = HashSet::xor_from(*key, block_length, seed);
+                for key in $keys.clone() {
+                    let HashSet { hash, hset } = HashSet::xor_from(key, block_length, seed);
 
                     for b in 0..3 {
                         let setindex = hset[b];

--- a/src/xor16.rs
+++ b/src/xor16.rs
@@ -69,21 +69,36 @@ impl Filter<u64> for Xor16 {
     }
 }
 
+impl Xor16 {
+    /// Construct the filter from a key iterator. Can be used directly
+    /// if you don't have a contiguous array of u64 keys.
+    ///
+    /// Note: the iterator will be iterated over multiple times while building
+    /// the filter. If using a hash function to map the key, it may be cheaper
+    /// just to create a scratch array of hashed keys that you pass in.
+    pub fn from_iterator<T>(keys: T) -> Self
+    where
+        T: ExactSizeIterator<Item = u64> + Clone,
+    {
+        xor_from_impl!(keys fingerprint u16)
+    }
+}
+
 impl From<&[u64]> for Xor16 {
     fn from(keys: &[u64]) -> Self {
-        xor_from_impl!(keys fingerprint u16)
+        Self::from_iterator(keys.iter().copied())
     }
 }
 
 impl From<&Vec<u64>> for Xor16 {
     fn from(v: &Vec<u64>) -> Self {
-        Self::from(v.as_slice())
+        Self::from_iterator(v.iter().copied())
     }
 }
 
 impl From<Vec<u64>> for Xor16 {
     fn from(v: Vec<u64>) -> Self {
-        Self::from(v.as_slice())
+        Self::from_iterator(v.iter().copied())
     }
 }
 

--- a/src/xor32.rs
+++ b/src/xor32.rs
@@ -69,21 +69,36 @@ impl Filter<u64> for Xor32 {
     }
 }
 
+impl Xor32 {
+    /// Construct the filter from a key iterator. Can be used directly
+    /// if you don't have a contiguous array of u64 keys.
+    ///
+    /// Note: the iterator will be iterated over multiple times while building
+    /// the filter. If using a hash function to map the key, it may be cheaper
+    /// just to create a scratch array of hashed keys that you pass in.
+    pub fn from_iterator<T>(keys: T) -> Self
+    where
+        T: ExactSizeIterator<Item = u64> + Clone,
+    {
+        xor_from_impl!(keys fingerprint u32)
+    }
+}
+
 impl From<&[u64]> for Xor32 {
     fn from(keys: &[u64]) -> Self {
-        xor_from_impl!(keys fingerprint u32)
+        Self::from_iterator(keys.iter().copied())
     }
 }
 
 impl From<&Vec<u64>> for Xor32 {
     fn from(v: &Vec<u64>) -> Self {
-        Self::from(v.as_slice())
+        Self::from_iterator(v.iter().copied())
     }
 }
 
 impl From<Vec<u64>> for Xor32 {
     fn from(v: Vec<u64>) -> Self {
-        Self::from(v.as_slice())
+        Self::from_iterator(v.iter().copied())
     }
 }
 

--- a/src/xor8.rs
+++ b/src/xor8.rs
@@ -69,21 +69,36 @@ impl Filter<u64> for Xor8 {
     }
 }
 
+impl Xor8 {
+    /// Construct the filter from a key iterator. Can be used directly
+    /// if you don't have a contiguous array of u64 keys.
+    ///
+    /// Note: the iterator will be iterated over multiple times while building
+    /// the filter. If using a hash function to map the key, it may be cheaper
+    /// just to create a scratch array of hashed keys that you pass in.
+    pub fn from_iterator<T>(keys: T) -> Self
+    where
+        T: ExactSizeIterator<Item = u64> + Clone,
+    {
+        xor_from_impl!(keys fingerprint u8)
+    }
+}
+
 impl From<&[u64]> for Xor8 {
     fn from(keys: &[u64]) -> Self {
-        xor_from_impl!(keys fingerprint u8)
+        Self::from_iterator(keys.iter().copied())
     }
 }
 
 impl From<&Vec<u64>> for Xor8 {
     fn from(v: &Vec<u64>) -> Self {
-        Self::from(v.as_slice())
+        Self::from_iterator(v.iter().copied())
     }
 }
 
 impl From<Vec<u64>> for Xor8 {
     fn from(v: Vec<u64>) -> Self {
-        Self::from(v.as_slice())
+        Self::from_iterator(v.iter().copied())
     }
 }
 


### PR DESCRIPTION
Add a helper to construct using an iterator. I'm not convinced these benchmark results aren't indicative of some kind
of machine setup issue on my end. Can't imagine why there'd be an across-the-board perf improvement like that and
on the previous run I did (before I added the new benchmarks) I saw a mix of improvements and regressions.

```    
    BinaryFuse16/from/500000
                            time:   [19.930 ms 19.993 ms 20.060 ms]
                            change: [-17.320% -8.1279% +1.8364%] (p = 0.17 > 0.05)
                            No change in performance detected.
    
    BinaryFuse32/from/500000
                            time:   [19.161 ms 19.305 ms 19.526 ms]
                            change: [-33.901% -21.972% -9.3098%] (p = 0.01 < 0.05)
                            Performance has improved.
    
    BinaryFuse8/from/500000 time:   [18.473 ms 18.537 ms 18.670 ms]
                            change: [-36.472% -26.878% -17.103%] (p = 0.00 < 0.05)
                            Performance has improved.
    
    Fuse16/from/500000      time:   [29.237 ms 29.529 ms 30.126 ms]
                            change: [-53.901% -34.098% -9.1085%] (p = 0.07 > 0.05)
                            No change in performance detected.
    
    Fuse32/from/500000      time:   [30.281 ms 30.392 ms 30.601 ms]
                            change: [-35.093% -20.946% -6.5932%] (p = 0.03 < 0.05)
                            Performance has improved.
    
    Fuse8/from/500000       time:   [29.309 ms 37.546 ms 45.843 ms]
                            change: [-56.022% -43.412% -23.294%] (p = 0.00 < 0.05)
                            Performance has improved.
    
    Xor16/from/500000       time:   [42.116 ms 44.413 ms 46.674 ms]
                            change: [-44.116% -32.964% -18.902%] (p = 0.00 < 0.05)
                            Performance has improved.
    
    Xor32/from/500000       time:   [42.222 ms 42.648 ms 43.433 ms]
                            change: [-6.5170% +0.2829% +7.5735%] (p = 0.95 > 0.05)
                            No change in performance detected.
    
    Xor8/from/500000        time:   [40.687 ms 41.027 ms 41.439 ms]
                            change: [-43.893% -32.745% -17.619%] (p = 0.00 < 0.05)
                            Performance has improved.
```

Resolves #59 