### PR TITLE
Expose `prelude` helpers and `bfuse` struct fields

### DIFF
--- a/src/bfuse16.rs
+++ b/src/bfuse16.rs
@@ -56,10 +56,12 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct BinaryFuse16 {
-    seed: u64,
-    segment_length: u32,
-    segment_length_mask: u32,
-    segment_count_length: u32,
+    /// The seed for the filter
+    pub seed: u64,
+    /// The number of blocks in the filter
+    pub segment_length: u32,
+    pub segment_length_mask: u32,
+    pub segment_count_length: u32,
     /// The fingerprints for the filter
     pub fingerprints: Box<[u16]>,
 }

--- a/src/bfuse32.rs
+++ b/src/bfuse32.rs
@@ -57,10 +57,12 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct BinaryFuse32 {
-    seed: u64,
-    segment_length: u32,
-    segment_length_mask: u32,
-    segment_count_length: u32,
+    /// The seed for the filter
+    pub seed: u64,
+    /// The number of blocks in the filter
+    pub segment_length: u32,
+    pub segment_length_mask: u32,
+    pub segment_count_length: u32,
     /// The fingerprints for the filter
     pub fingerprints: Box<[u32]>,
 }

--- a/src/bfuse8.rs
+++ b/src/bfuse8.rs
@@ -56,10 +56,12 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct BinaryFuse8 {
-    seed: u64,
-    segment_length: u32,
-    segment_length_mask: u32,
-    segment_count_length: u32,
+    /// The seed for the filter
+    pub seed: u64,
+    /// The number of blocks in the filter
+    pub segment_length: u32,
+    pub segment_length_mask: u32,
+    pub segment_count_length: u32,
     /// The fingerprints for the filter
     pub fingerprints: Box<[u8]>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@
 extern crate alloc;
 
 mod murmur3;
-mod prelude;
+pub mod prelude;
 mod splitmix64;
 
 #[cfg(feature = "binary-fuse")]

--- a/src/prelude/mod.rs
+++ b/src/prelude/mod.rs
@@ -44,6 +44,7 @@ macro_rules! fingerprint(
         $hash ^ ($hash >> 32)
     };
 );
+pub use fingerprint;
 
 /// Rotate left
 #[doc(hidden)]


### PR DESCRIPTION
## What?
In order to allow developers to be more fine-grained with their usage of this crate, I am proposing simply `pub` placements that I am currently using to expose certain methods and fields necessary to compute the hash indices manually.

## Why?
I found in benchmarking that I could significantly improve the lookup function in my code by only reading the initial metadata about the filter (seed and in the context of bfuse, segment information), computing the hash myself, and `seek_read`ing the individual bytes from the file in which I am storing the built filters to determine if a key is contained within the filter. I am not knowledgeable enough with the filters themselves to be able to properly document the segment information or the prelude functions, so that may still be needed.