### PR TITLE
Add `Clone` derivation for Filters

### DIFF
--- a/src/bfuse16.rs
+++ b/src/bfuse16.rs
@@ -58,7 +58,7 @@ use bincode::{Decode, Encode};
 /// [`serde`]: http://serde.rs
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BinaryFuse16 {
     seed: u64,
     segment_length: u32,

--- a/src/bfuse32.rs
+++ b/src/bfuse32.rs
@@ -59,7 +59,7 @@ use bincode::{Decode, Encode};
 /// [`serde`]: http://serde.rs
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BinaryFuse32 {
     seed: u64,
     segment_length: u32,

--- a/src/bfuse8.rs
+++ b/src/bfuse8.rs
@@ -59,7 +59,7 @@ use bincode::{Decode, Encode};
 /// [`serde`]: http://serde.rs
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BinaryFuse8 {
     seed: u64,
     segment_length: u32,

--- a/src/fuse16.rs
+++ b/src/fuse16.rs
@@ -63,7 +63,7 @@ use bincode::{Decode, Encode};
 #[deprecated(since = "0.8.0", note = "prefer using a `BinaryFuse16`")]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Fuse16 {
     /// The seed for the filter
     pub seed: u64,

--- a/src/fuse32.rs
+++ b/src/fuse32.rs
@@ -63,7 +63,7 @@ use bincode::{Decode, Encode};
 #[deprecated(since = "0.8.0", note = "prefer using a `BinaryFuse32`")]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Fuse32 {
     /// The seed for the filter
     pub seed: u64,

--- a/src/fuse8.rs
+++ b/src/fuse8.rs
@@ -63,7 +63,7 @@ use bincode::{Decode, Encode};
 #[deprecated(since = "0.8.0", note = "prefer using a `BinaryFuse8`")]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Fuse8 {
     /// The seed for the filter
     pub seed: u64,

--- a/src/xor16.rs
+++ b/src/xor16.rs
@@ -53,6 +53,7 @@ use bincode::{Decode, Encode};
 /// [`serde`]: http://serde.rs
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
+#[derive(Debug, Clone)]
 pub struct Xor16 {
     /// The seed for the filter
     pub seed: u64,

--- a/src/xor32.rs
+++ b/src/xor32.rs
@@ -53,6 +53,7 @@ use bincode::{Decode, Encode};
 /// [`serde`]: http://serde.rs
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
+#[derive(Debug, Clone)]
 pub struct Xor32 {
     /// The seed for the filter
     pub seed: u64,

--- a/src/xor8.rs
+++ b/src/xor8.rs
@@ -53,6 +53,7 @@ use bincode::{Decode, Encode};
 /// [`serde`]: http://serde.rs
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
+#[derive(Debug, Clone)]
 pub struct Xor8 {
     /// The seed for the filter
     pub seed: u64,


### PR DESCRIPTION
No reason to have them not be AFAICT and makes certain things easier (e.g. if the filter is part of a data structure whose ownership is being transferred but you want to keep a copy of the filter).