### PR TITLE
Use serde_bytes to optimize (de)serilization speed of 8-bit filters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ rand = { version = "0.8", optional = true }
 criterion = "0.3.0"
 criterion-macro = "0.3.0"
 rand = "0.8"
+bincode = { version = "2.0.0-rc.3", default-features = false, features = ["std", "derive", "serde"]}
 
 [[bench]]
 name = "bfuse32"
@@ -51,6 +52,7 @@ harness = false
 [[bench]]
 name = "bfuse8"
 harness = false
+required-features = ["serde"]
 
 [[bench]]
 name = "fuse32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ repository = "ayazhafiz/xorf"
 [dependencies]
 libm = { version = "0.2.1", optional = true }
 serde = { version = "1.0.104", optional = true, features = ["derive"] }
+serde_bytes = { version = "0.11.12", optional = true }
 bincode = { version = "2.0.0-rc.3", default-features = false, optional = true, features = ["std", "derive"]} 
 num-traits = { version = "0.2.12", optional = true }
 rand = { version = "0.8", optional = true }
@@ -79,3 +80,4 @@ harness = false
 default = ["uniform-random", "binary-fuse"]
 uniform-random = ["rand"]
 binary-fuse = ["libm"]
+serde = ["dep:serde", "serde_bytes"]

--- a/benches/bfuse8.rs
+++ b/benches/bfuse8.rs
@@ -4,12 +4,42 @@ extern crate core;
 extern crate rand;
 extern crate xorf;
 
+use bincode::serde;
 use core::convert::TryFrom;
 use criterion::{BenchmarkId, Criterion};
 use rand::Rng;
 use xorf::{BinaryFuse8, Filter};
 
 const SAMPLE_SIZE: u32 = 500_000;
+
+fn serialization(c: &mut Criterion) {
+    let mut group = c.benchmark_group("BinaryFuse8");
+    let group = group.sample_size(10);
+
+    let mut rng = rand::thread_rng();
+    let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+
+    let filter = BinaryFuse8::try_from(keys).unwrap();
+    let config = bincode::config::standard();
+
+    group.bench_with_input(
+        BenchmarkId::new("serde-serialize", SAMPLE_SIZE),
+        &filter,
+        |b, filter| {
+            b.iter(|| serde::encode_to_vec(filter, config).unwrap());
+        },
+    );
+
+    let serialized_filter = serde::encode_to_vec(&filter, config).unwrap();
+
+    group.bench_with_input(
+        BenchmarkId::new("serde-deserialize", SAMPLE_SIZE),
+        &serialized_filter,
+        |b, filter| {
+            b.iter(|| serde::decode_from_slice::<BinaryFuse8, _>(filter, config).unwrap());
+        },
+    );
+}
 
 fn from(c: &mut Criterion) {
     let mut group = c.benchmark_group("BinaryFuse8");
@@ -36,5 +66,5 @@ fn contains(c: &mut Criterion) {
     });
 }
 
-criterion_group!(bfuse8, from, contains);
+criterion_group!(bfuse8, serialization, from, contains);
 criterion_main!(bfuse8);

--- a/src/bfuse8.rs
+++ b/src/bfuse8.rs
@@ -66,6 +66,7 @@ pub struct BinaryFuse8 {
     segment_length_mask: u32,
     segment_count_length: u32,
     /// The fingerprints for the filter
+    #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
     pub fingerprints: Box<[u8]>,
 }
 

--- a/src/fuse8.rs
+++ b/src/fuse8.rs
@@ -70,6 +70,7 @@ pub struct Fuse8 {
     /// The number of blocks in the filter
     pub segment_length: usize,
     /// The fingerprints for the filter
+    #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
     pub fingerprints: Box<[u8]>,
 }
 

--- a/src/xor8.rs
+++ b/src/xor8.rs
@@ -60,6 +60,7 @@ pub struct Xor8 {
     /// The number of blocks in the filter
     pub block_length: usize,
     /// The fingerprints for the filter
+    #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
     pub fingerprints: Box<[u8]>,
 }
 


### PR DESCRIPTION
```
BinaryFuse8/serialize/500000
                        time:   [263.42 µs 269.47 µs 272.86 µs]
BinaryFuse8/deserialize/500000
                        time:   [1.2453 ms 1.2498 ms 1.2553 ms]
```

```
BinaryFuse8/serialize/500000
                        time:   [9.4238 µs 9.4404 µs 9.4479 µs]
                        change: [-96.524% -96.466% -96.401%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) low mild
BinaryFuse8/deserialize/500000
                        time:   [14.670 µs 14.727 µs 14.801 µs]
                        change: [-98.822% -98.816% -98.809%] (p = 0.00 < 0.05)
                        Performance has improved
```
