### PR TITLE
use Borrow to allow more types in .contains() calls

### DIFF
--- a/src/bfuse16.rs
+++ b/src/bfuse16.rs
@@ -30,7 +30,7 @@ use bincode::{Decode, Encode};
 ///
 /// # let mut rng = rand::thread_rng();
 /// const SAMPLE_SIZE: usize = 1_000_000;
-/// let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+/// let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 /// let filter = BinaryFuse16::try_from(&keys).unwrap();
 ///
 /// // no false negatives
@@ -44,7 +44,7 @@ use bincode::{Decode, Encode};
 ///
 /// // false positive rate
 /// let false_positives: usize = (0..SAMPLE_SIZE)
-///     .map(|_| rng.gen())
+///     .map(|_| rng.gen::<u64>())
 ///     .filter(|n| filter.contains(n))
 ///     .count();
 /// let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;
@@ -72,8 +72,8 @@ impl Filter<u64> for BinaryFuse16 {
     /// Returns `true` if the filter contains the specified key.
     /// Has a false positive rate of <0.4%.
     /// Has no false negatives.
-    fn contains(&self, key: &u64) -> bool {
-        bfuse_contains_impl!(*key, self, fingerprint u16)
+    fn contains<Q: crate::Borrow<u64>>(&self, key: &Q) -> bool {
+        bfuse_contains_impl!(*key.borrow(), self, fingerprint u16)
     }
 
     fn len(&self) -> usize {
@@ -132,7 +132,7 @@ mod test {
     fn test_initialization() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = BinaryFuse16::try_from(&keys).unwrap();
 
@@ -145,7 +145,7 @@ mod test {
     fn test_bits_per_entry() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = BinaryFuse16::try_from(&keys).unwrap();
         let bpe = (filter.len() as f64) * 16.0 / (SAMPLE_SIZE as f64);
@@ -157,12 +157,12 @@ mod test {
     fn test_false_positives() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = BinaryFuse16::try_from(&keys).unwrap();
 
         let false_positives: usize = (0..SAMPLE_SIZE)
-            .map(|_| rng.gen())
+            .map(|_| rng.gen::<u64>())
             .filter(|n| filter.contains(n))
             .count();
         let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;

--- a/src/bfuse32.rs
+++ b/src/bfuse32.rs
@@ -31,7 +31,7 @@ use bincode::{Decode, Encode};
 ///
 /// # let mut rng = rand::thread_rng();
 /// const SAMPLE_SIZE: usize = 1_000_000;
-/// let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+/// let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 /// let filter = BinaryFuse32::try_from(&keys).unwrap();
 ///
 /// // no false negatives
@@ -45,7 +45,7 @@ use bincode::{Decode, Encode};
 ///
 /// // false positive rate
 /// let false_positives: usize = (0..SAMPLE_SIZE)
-///     .map(|_| rng.gen())
+///     .map(|_| rng.gen::<u64>())
 ///     .filter(|n| filter.contains(n))
 ///     .count();
 /// let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;
@@ -73,8 +73,8 @@ impl Filter<u64> for BinaryFuse32 {
     /// Returns `true` if the filter contains the specified key.
     /// Has a false positive rate of <0.4%.
     /// Has no false negatives.
-    fn contains(&self, key: &u64) -> bool {
-        bfuse_contains_impl!(*key, self, fingerprint u32)
+    fn contains<Q: crate::Borrow<u64>>(&self, key: &Q) -> bool {
+        bfuse_contains_impl!(*key.borrow(), self, fingerprint u32)
     }
 
     fn len(&self) -> usize {
@@ -133,7 +133,7 @@ mod test {
     fn test_initialization() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = BinaryFuse32::try_from(&keys).unwrap();
 
@@ -146,7 +146,7 @@ mod test {
     fn test_bits_per_entry() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = BinaryFuse32::try_from(&keys).unwrap();
         let bpe = (filter.len() as f64) * 32.0 / (SAMPLE_SIZE as f64);
@@ -158,12 +158,12 @@ mod test {
     fn test_false_positives() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = BinaryFuse32::try_from(&keys).unwrap();
 
         let false_positives: usize = (0..SAMPLE_SIZE)
-            .map(|_| rng.gen())
+            .map(|_| rng.gen::<u64>())
             .filter(|n| filter.contains(n))
             .count();
         let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;

--- a/src/bfuse8.rs
+++ b/src/bfuse8.rs
@@ -30,7 +30,7 @@ use bincode::{Decode, Encode};
 ///
 /// # let mut rng = rand::thread_rng();
 /// const SAMPLE_SIZE: usize = 1_000_000;
-/// let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+/// let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 /// let filter = BinaryFuse8::try_from(&keys).unwrap();
 ///
 /// // no false negatives
@@ -44,7 +44,7 @@ use bincode::{Decode, Encode};
 ///
 /// // false positive rate
 /// let false_positives: usize = (0..SAMPLE_SIZE)
-///     .map(|_| rng.gen())
+///     .map(|_| rng.gen::<u64>())
 ///     .filter(|n| filter.contains(n))
 ///     .count();
 /// let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;
@@ -73,8 +73,8 @@ impl Filter<u64> for BinaryFuse8 {
     /// Returns `true` if the filter contains the specified key.
     /// Has a false positive rate of <0.4%.
     /// Has no false negatives.
-    fn contains(&self, key: &u64) -> bool {
-        bfuse_contains_impl!(*key, self, fingerprint u8)
+    fn contains<Q: crate::Borrow<u64>>(&self, key: &Q) -> bool {
+        bfuse_contains_impl!(*key.borrow(), self, fingerprint u8)
     }
 
     fn len(&self) -> usize {
@@ -133,7 +133,7 @@ mod test {
     fn test_initialization() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = BinaryFuse8::try_from(&keys).unwrap();
 
@@ -146,7 +146,7 @@ mod test {
     fn test_bits_per_entry() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = BinaryFuse8::try_from(&keys).unwrap();
         let bpe = (filter.len() as f64) * 8.0 / (SAMPLE_SIZE as f64);
@@ -158,12 +158,12 @@ mod test {
     fn test_false_positives() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = BinaryFuse8::try_from(&keys).unwrap();
 
         let false_positives: usize = (0..SAMPLE_SIZE)
-            .map(|_| rng.gen())
+            .map(|_| rng.gen::<u64>())
             .filter(|n| filter.contains(n))
             .count();
         let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;

--- a/src/fuse16.rs
+++ b/src/fuse16.rs
@@ -34,7 +34,7 @@ use bincode::{Decode, Encode};
 ///
 /// # let mut rng = rand::thread_rng();
 /// const SAMPLE_SIZE: usize = 1_000_000;
-/// let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+/// let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 /// let filter = Fuse16::try_from(&keys).unwrap();
 ///
 /// // no false negatives
@@ -48,7 +48,7 @@ use bincode::{Decode, Encode};
 ///
 /// // false positive rate
 /// let false_positives: usize = (0..SAMPLE_SIZE)
-///     .map(|_| rng.gen())
+///     .map(|_| rng.gen::<u64>())
 ///     .filter(|n| filter.contains(n))
 ///     .count();
 /// let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;
@@ -75,8 +75,8 @@ pub struct Fuse16 {
 
 impl Filter<u64> for Fuse16 {
     /// Returns `true` if the filter contains the specified key. Has a false positive rate of <0.002%.
-    fn contains(&self, key: &u64) -> bool {
-        fuse_contains_impl!(*key, self, fingerprint u16)
+    fn contains<Q: crate::Borrow<u64>>(&self, key: &Q) -> bool {
+        fuse_contains_impl!(*key.borrow(), self, fingerprint u16)
     }
 
     fn len(&self) -> usize {
@@ -135,7 +135,7 @@ mod test {
     fn test_initialization() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = Fuse16::try_from(&keys).unwrap();
 
@@ -148,7 +148,7 @@ mod test {
     fn test_bits_per_entry() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = Fuse16::try_from(&keys).unwrap();
         let bpe = (filter.len() as f64) * 16.0 / (SAMPLE_SIZE as f64);
@@ -160,12 +160,12 @@ mod test {
     fn test_false_positives() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = Fuse16::try_from(&keys).unwrap();
 
         let false_positives: usize = (0..SAMPLE_SIZE)
-            .map(|_| rng.gen())
+            .map(|_| rng.gen::<u64>())
             .filter(|n| filter.contains(n))
             .count();
         let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;
@@ -176,7 +176,7 @@ mod test {
     fn test_fail_construction() {
         const SAMPLE_SIZE: usize = 1_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = Fuse16::try_from(&keys);
         assert!(filter.expect_err("") == "Failed to construct fuse filter.");

--- a/src/fuse32.rs
+++ b/src/fuse32.rs
@@ -34,7 +34,7 @@ use bincode::{Decode, Encode};
 ///
 /// # let mut rng = rand::thread_rng();
 /// const SAMPLE_SIZE: usize = 1_000_000;
-/// let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+/// let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 /// let filter = Fuse32::try_from(&keys).unwrap();
 ///
 /// // no false negatives
@@ -48,7 +48,7 @@ use bincode::{Decode, Encode};
 ///
 /// // false positive rate
 /// let false_positives: usize = (0..SAMPLE_SIZE)
-///     .map(|_| rng.gen())
+///     .map(|_| rng.gen::<u64>())
 ///     .filter(|n| filter.contains(n))
 ///     .count();
 /// let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;
@@ -75,8 +75,8 @@ pub struct Fuse32 {
 
 impl Filter<u64> for Fuse32 {
     /// Returns `true` if the filter contains the specified key.
-    fn contains(&self, key: &u64) -> bool {
-        fuse_contains_impl!(*key, self, fingerprint u32)
+    fn contains<Q: crate::Borrow<u64>>(&self, key: &Q) -> bool {
+        fuse_contains_impl!(*key.borrow(), self, fingerprint u32)
     }
 
     fn len(&self) -> usize {
@@ -135,7 +135,7 @@ mod test {
     fn test_initialization() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = Fuse32::try_from(&keys).unwrap();
 
@@ -148,7 +148,7 @@ mod test {
     fn test_bits_per_entry() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = Fuse32::try_from(&keys).unwrap();
         let bpe = (filter.len() as f64) * 32.0 / (SAMPLE_SIZE as f64);
@@ -168,12 +168,12 @@ mod test {
     fn test_false_positives() {
         const SAMPLE_SIZE: usize = 1_000_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = Fuse32::try_from(&keys).unwrap();
 
         let false_positives: usize = (0..SAMPLE_SIZE)
-            .map(|_| rng.gen())
+            .map(|_| rng.gen::<u64>())
             .filter(|n| filter.contains(n))
             .count();
         let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;
@@ -188,7 +188,7 @@ mod test {
     fn test_fail_construction() {
         const SAMPLE_SIZE: usize = 1_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = Fuse32::try_from(&keys);
         assert!(filter.expect_err("") == "Failed to construct fuse filter.");

--- a/src/fuse8.rs
+++ b/src/fuse8.rs
@@ -34,7 +34,7 @@ use bincode::{Decode, Encode};
 ///
 /// # let mut rng = rand::thread_rng();
 /// const SAMPLE_SIZE: usize = 1_000_000;
-/// let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+/// let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 /// let filter = Fuse8::try_from(&keys).unwrap();
 ///
 /// // no false negatives
@@ -48,7 +48,7 @@ use bincode::{Decode, Encode};
 ///
 /// // false positive rate
 /// let false_positives: usize = (0..SAMPLE_SIZE)
-///     .map(|_| rng.gen())
+///     .map(|_| rng.gen::<u64>())
 ///     .filter(|n| filter.contains(n))
 ///     .count();
 /// let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;
@@ -75,8 +75,8 @@ pub struct Fuse8 {
 
 impl Filter<u64> for Fuse8 {
     /// Returns `true` if the filter contains the specified key. Has a false positive rate of <0.4%.
-    fn contains(&self, key: &u64) -> bool {
-        fuse_contains_impl!(*key, self, fingerprint u8)
+    fn contains<Q: crate::Borrow<u64>>(&self, key: &Q) -> bool {
+        fuse_contains_impl!(*key.borrow(), self, fingerprint u8)
     }
 
     fn len(&self) -> usize {
@@ -135,7 +135,7 @@ mod test {
     fn test_initialization() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = Fuse8::try_from(&keys).unwrap();
 
@@ -148,7 +148,7 @@ mod test {
     fn test_bits_per_entry() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = Fuse8::try_from(&keys).unwrap();
         let bpe = (filter.len() as f64) * 8.0 / (SAMPLE_SIZE as f64);
@@ -160,12 +160,12 @@ mod test {
     fn test_false_positives() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = Fuse8::try_from(&keys).unwrap();
 
         let false_positives: usize = (0..SAMPLE_SIZE)
-            .map(|_| rng.gen())
+            .map(|_| rng.gen::<u64>())
             .filter(|n| filter.contains(n))
             .count();
         let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;
@@ -176,7 +176,7 @@ mod test {
     fn test_fail_construction() {
         const SAMPLE_SIZE: usize = 1_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = Fuse8::try_from(&keys);
         assert!(filter.expect_err("") == "Failed to construct fuse filter.");

--- a/src/hash_proxy.rs
+++ b/src/hash_proxy.rs
@@ -112,8 +112,9 @@ where
     F: Filter<u64>,
 {
     /// Returns `true` if the underlying filter contains the specified key.
-    fn contains(&self, key: &T) -> bool {
-        self.filter.contains(&hash::<T, H>(key))
+    fn contains<Q: crate::Borrow<T>>(&self, key: &Q) -> bool
+    {
+        self.filter.contains(&hash::<T, H>(key.borrow()))
     }
 
     fn len(&self) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,7 @@ pub use hash_proxy::HashProxy;
 pub use xor16::Xor16;
 pub use xor32::Xor32;
 pub use xor8::Xor8;
+use core::borrow::Borrow;
 
 /// Methods common to xor filters.
 pub trait Filter<Type> {
@@ -116,7 +117,8 @@ pub trait Filter<Type> {
     ///
     /// There can never be a false negative, but there is a small possibility of false positives.
     /// Refer to individual filters' documentation for false positive rates.
-    fn contains(&self, key: &Type) -> bool;
+    fn contains<Q: Borrow<Type>>(&self, key: &Q) -> bool;
+
 
     /// Returns the number of fingerprints in the filter.
     fn len(&self) -> usize;

--- a/src/xor16.rs
+++ b/src/xor16.rs
@@ -27,7 +27,7 @@ use bincode::{Decode, Encode};
 ///
 /// # let mut rng = rand::thread_rng();
 /// const SAMPLE_SIZE: usize = 1_000_000;
-/// let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+/// let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 /// let filter = Xor16::from(&keys);
 ///
 /// // no false negatives
@@ -41,7 +41,7 @@ use bincode::{Decode, Encode};
 ///
 /// // false positive rate
 /// let false_positives: usize = (0..SAMPLE_SIZE)
-///     .map(|_| rng.gen())
+///     .map(|_| rng.gen::<u64>())
 ///     .filter(|n| filter.contains(n))
 ///     .count();
 /// let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;
@@ -65,8 +65,8 @@ pub struct Xor16 {
 
 impl Filter<u64> for Xor16 {
     /// Returns `true` if the filter contains the specified key. Has a false positive rate of <0.002%.
-    fn contains(&self, key: &u64) -> bool {
-        xor_contains_impl!(*key, self, fingerprint u16)
+    fn contains<Q: crate::Borrow<u64>>(&self, key: &Q) -> bool {
+        xor_contains_impl!(*key.borrow(), self, fingerprint u16)
     }
 
     fn len(&self) -> usize {
@@ -118,7 +118,7 @@ mod test {
     fn test_initialization() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = Xor16::from(&keys);
 
@@ -131,7 +131,7 @@ mod test {
     fn test_bits_per_entry() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = Xor16::from(&keys);
         let bpe = (filter.len() as f64) * 16.0 / (SAMPLE_SIZE as f64);
@@ -143,12 +143,12 @@ mod test {
     fn test_false_positives() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = Xor16::from(&keys);
 
         let false_positives: usize = (0..SAMPLE_SIZE)
-            .map(|_| rng.gen())
+            .map(|_| rng.gen::<u64>())
             .filter(|n| filter.contains(n))
             .count();
         let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;

--- a/src/xor32.rs
+++ b/src/xor32.rs
@@ -27,7 +27,7 @@ use bincode::{Decode, Encode};
 ///
 /// # let mut rng = rand::thread_rng();
 /// const SAMPLE_SIZE: usize = 1_000_000;
-/// let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+/// let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 /// let filter = Xor32::from(&keys);
 ///
 /// // no false negatives
@@ -41,7 +41,7 @@ use bincode::{Decode, Encode};
 ///
 /// // false positive rate
 /// let false_positives: usize = (0..SAMPLE_SIZE)
-///     .map(|_| rng.gen())
+///     .map(|_| rng.gen::<u64>())
 ///     .filter(|n| filter.contains(n))
 ///     .count();
 /// let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;
@@ -65,8 +65,8 @@ pub struct Xor32 {
 
 impl Filter<u64> for Xor32 {
     /// Returns `true` if the filter contains the specified key.
-    fn contains(&self, key: &u64) -> bool {
-        xor_contains_impl!(*key, self, fingerprint u32)
+    fn contains<Q: crate::Borrow<u64>>(&self, key: &Q) -> bool {
+        xor_contains_impl!(*key.borrow(), self, fingerprint u32)
     }
 
     fn len(&self) -> usize {
@@ -118,7 +118,7 @@ mod test {
     fn test_initialization() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = Xor32::from(&keys);
 
@@ -131,7 +131,7 @@ mod test {
     fn test_bits_per_entry() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = Xor32::from(&keys);
         let bpe = (filter.len() as f64) * 32.0 / (SAMPLE_SIZE as f64);
@@ -151,12 +151,12 @@ mod test {
     fn test_false_positives() {
         const SAMPLE_SIZE: usize = 1_000_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = Xor32::from(&keys);
 
         let false_positives: usize = (0..SAMPLE_SIZE)
-            .map(|_| rng.gen())
+            .map(|_| rng.gen::<u64>())
             .filter(|n| filter.contains(n))
             .count();
         let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;

--- a/src/xor8.rs
+++ b/src/xor8.rs
@@ -27,7 +27,7 @@ use bincode::{Decode, Encode};
 ///
 /// # let mut rng = rand::thread_rng();
 /// const SAMPLE_SIZE: usize = 1_000_000;
-/// let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+/// let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 /// let filter = Xor8::from(&keys);
 ///
 /// // no false negatives
@@ -41,7 +41,7 @@ use bincode::{Decode, Encode};
 ///
 /// // false positive rate
 /// let false_positives: usize = (0..SAMPLE_SIZE)
-///     .map(|_| rng.gen())
+///     .map(|_| rng.gen::<u64>())
 ///     .filter(|n| filter.contains(n))
 ///     .count();
 /// let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;
@@ -65,8 +65,8 @@ pub struct Xor8 {
 
 impl Filter<u64> for Xor8 {
     /// Returns `true` if the filter contains the specified key. Has a false positive rate of <0.4%.
-    fn contains(&self, key: &u64) -> bool {
-        xor_contains_impl!(*key, self, fingerprint u8)
+    fn contains<Q: crate::Borrow<u64>>(&self, key: &Q) -> bool {
+        xor_contains_impl!(*key.borrow(), self, fingerprint u8)
     }
 
     fn len(&self) -> usize {
@@ -118,7 +118,7 @@ mod test {
     fn test_initialization() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = Xor8::from(&keys);
 
@@ -131,7 +131,7 @@ mod test {
     fn test_bits_per_entry() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = Xor8::from(&keys);
         let bpe = (filter.len() as f64) * 8.0 / (SAMPLE_SIZE as f64);
@@ -143,12 +143,12 @@ mod test {
     fn test_false_positives() {
         const SAMPLE_SIZE: usize = 1_000_000;
         let mut rng = rand::thread_rng();
-        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen()).collect();
+        let keys: Vec<u64> = (0..SAMPLE_SIZE).map(|_| rng.gen::<u64>()).collect();
 
         let filter = Xor8::from(&keys);
 
         let false_positives: usize = (0..SAMPLE_SIZE)
-            .map(|_| rng.gen())
+            .map(|_| rng.gen::<u64>())
             .filter(|n| filter.contains(n))
             .count();
         let fp_rate: f64 = (false_positives * 100) as f64 / SAMPLE_SIZE as f64;


### PR DESCRIPTION
closes #82
some thougts:
this is mainly useful for the hash_proxy so maybe it should just be implemented on that type specifically in addition to the generic Filter::contains()?

the code is _very_ repetative, especially within the classes (x8 x16 x32) but also between. Maybe using generics or one big macro would be an idea?