### PR TITLE
chore: change visibility of binary fuse descriptor

### DIFF
--- a/src/bfuse16.rs
+++ b/src/bfuse16.rs
@@ -65,8 +65,9 @@ use bincode::{Decode, Encode};
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Debug, Clone)]
 pub struct BinaryFuse16 {
+    /// The descriptor which contains metadata about the filter
     #[cfg_attr(feature = "serde", serde(flatten))]
-    descriptor: Descriptor,
+    pub descriptor: Descriptor,
     /// The fingerprints for the filter
     pub fingerprints: Box<[u16]>,
 }

--- a/src/bfuse32.rs
+++ b/src/bfuse32.rs
@@ -66,8 +66,9 @@ use bincode::{Decode, Encode};
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Debug, Clone)]
 pub struct BinaryFuse32 {
+    /// The descriptor which contains metadata about the filter
     #[cfg_attr(feature = "serde", serde(flatten))]
-    descriptor: Descriptor,
+    pub descriptor: Descriptor,
     /// The fingerprints for the filter
     pub fingerprints: Box<[u32]>,
 }

--- a/src/bfuse8.rs
+++ b/src/bfuse8.rs
@@ -65,8 +65,9 @@ use bincode::{Decode, Encode};
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Debug, Clone)]
 pub struct BinaryFuse8 {
+    /// The descriptor which contains metadata about the filter
     #[cfg_attr(feature = "serde", serde(flatten))]
-    descriptor: Descriptor,
+    pub descriptor: Descriptor,
     /// The fingerprints for the filter
     #[cfg_attr(feature = "serde", serde(with = "serde_bytes"))]
     pub fingerprints: Box<[u8]>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,8 @@ pub use fuse32::Fuse32;
 #[allow(deprecated)]
 pub use fuse8::Fuse8;
 pub use hash_proxy::HashProxy;
+#[cfg(feature = "binary-fuse")]
+pub use prelude::Descriptor;
 pub use xor16::Xor16;
 pub use xor32::Xor32;
 pub use xor8::Xor8;

--- a/src/prelude/bfuse.rs
+++ b/src/prelude/bfuse.rs
@@ -61,17 +61,23 @@ pub const fn mod3(x: u8) -> u8 {
     }
 }
 
+/// Descriptor for a binary fuse filter.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "bincode", derive(Encode, Decode))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Descriptor {
+    /// The seed used for hashing keys into the filter.
     pub seed: u64,
+    /// The length of each segment in the filter.
     pub segment_length: u32,
+    /// A mask used for segment length calculations.
     pub segment_length_mask: u32,
+    /// The total length of all segments combined.
     pub segment_count_length: u32,
 }
 
 impl Descriptor {
+    /// Length of the descriptor when serialized with [`DmaSerializable`].
     pub const DMA_LEN: usize = u64::BITS as usize / 8 + (u32::BITS as usize / 8) * 3;
 }
 

--- a/src/prelude/mod.rs
+++ b/src/prelude/mod.rs
@@ -7,6 +7,8 @@ pub mod xor;
 
 use crate::murmur3;
 
+pub use bfuse::Descriptor;
+
 /// A set of hashes indexing three blocks.
 pub struct HashSet {
     /// Key hash


### PR DESCRIPTION
As it is, since `fingerprints` is already public.